### PR TITLE
[#275] Feat: add feature to define concrete source for renderable textures instead of hard-linking by its asset id

### DIFF
--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/asset/KRenderableTextureCollection.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/asset/KRenderableTextureCollection.java
@@ -114,24 +114,26 @@ public final class KRenderableTextureCollection
             KRenderableTextureTypedef.RENDERABLE_TEXTURE_ASSET_TYPE
         );
 
-        KRenderableTextureSource source = asset.getEnum(
-            "source",
+        KRenderableTextureSource sourceType = asset.getEnum(
+            "source_type",
             KRenderableTextureSource.class
         );
-        switch (source) {
+
+        String source = Objects.requireNonNull(asset.getString("source"));
+        switch (sourceType) {
             case WHOLE_TEXTURE -> {
-                KTexture texture = this.textureCollection.getAsset(assetId);
+                KTexture texture = this.textureCollection.getAsset(source);
                 return KRenderableTexture.wrapIntoRectangle(assetId, topLeftCorner, texture, unit);
             }
             case SLICE_SET -> {
-                String sliceSetId = Objects.requireNonNull(asset.getString("slice_set"));
+                String sliceSetId = Objects.requireNonNull(source);
                 KTextureSliceSet set = this.textureSliceSetCollection.getAsset(sliceSetId);
                 return set.getTexture(assetId, topLeftCorner, unit);
             }
         }
 
         throw new KAssetLoadingException(
-            String.format("Unknown source: %s", source)
+            String.format("Unknown source: %s", sourceType)
         );
     }
 

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/type/KRenderableTextureTypedef.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/type/KRenderableTextureTypedef.java
@@ -19,7 +19,6 @@ package io.github.darthakiranihil.konna.graphics.type;
 import io.github.darthakiranihil.konna.core.io.KAssetDefinitionRule;
 import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KCompositeAssetDefinitionRuleBuilder;
-import io.github.darthakiranihil.konna.core.io.except.KAssetDefinitionError;
 import io.github.darthakiranihil.konna.graphics.image.KRenderableTextureSource;
 
 /**
@@ -58,20 +57,8 @@ public final class KRenderableTextureTypedef implements KAssetTypedef {
     public KAssetDefinitionRule getRule() {
         return KCompositeAssetDefinitionRuleBuilder
             .create()
-            .withEnum("source", KRenderableTextureSource.class)
-            .withString("slice_set")
-            .withRule(d -> {
-                String textureSetId = d.getString("slice_set");
-                KRenderableTextureSource source = d.getEnum(
-                    "source",
-                    KRenderableTextureSource.class
-                );
-                if (source == KRenderableTextureSource.SLICE_SET && textureSetId == null) {
-                    throw new KAssetDefinitionError(
-                        "Texture set id cannot be null if a renderable texture is taken from there"
-                    );
-                }
-            })
+            .withEnum("source_type", KRenderableTextureSource.class)
+            .withNotNullString("source")
             .build();
     }
 

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KRenderableTextureCollectionPositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KRenderableTextureCollectionPositiveTests.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-@Disabled
 public class KRenderableTextureCollectionPositiveTests extends KAssetCollectionTestClass {
 
     @Test

--- a/components/component-graphics/src/test/resources/assets/renderables/sl1.json
+++ b/components/component-graphics/src/test/resources/assets/renderables/sl1.json
@@ -1,21 +1,9 @@
 {
     "asset_id": "sl1",
     "type": "Graphics.renderableTexture",
-    "Graphics.texture": {
-        "image": "classpath:assets/textures/cute_image.png",
-        "shader": "default",
-        "wrapping": {
-            "u": "REPEAT",
-            "v": "REPEAT"
-        },
-        "filtering": {
-            "min": "MIPMAP_LINEAR_LINEAR",
-            "mag": "LINEAR"
-        }
-    },
     "schema_version": 1,
     "data": {
-        "source": "SLICE_SET",
-        "slice_set": "set_1"
+        "source_type": "SLICE_SET",
+        "source": "set_1"
     }
 }

--- a/components/component-graphics/src/test/resources/assets/renderables/sl2.json
+++ b/components/component-graphics/src/test/resources/assets/renderables/sl2.json
@@ -1,21 +1,9 @@
 {
     "asset_id": "slt2",
     "type": "Graphics.renderableTexture",
-    "Graphics.texture": {
-        "image": "classpath:assets/textures/cute_image.png",
-        "shader": "default",
-        "wrapping": {
-            "u": "REPEAT",
-            "v": "REPEAT"
-        },
-        "filtering": {
-            "min": "MIPMAP_LINEAR_LINEAR",
-            "mag": "LINEAR"
-        }
-    },
     "schema_version": 1,
     "data": {
-        "source": "WHOLE_TEXTURE",
-        "slice_set": null
+        "source_type": "WHOLE_TEXTURE",
+        "source": "tata2"
     }
 }

--- a/components/component-graphics/src/test/resources/assets/textures/tata2.json
+++ b/components/component-graphics/src/test/resources/assets/textures/tata2.json
@@ -1,0 +1,17 @@
+{
+    "asset_id": "tata2",
+    "type": "Graphics.texture",
+    "data": {
+        "image": "classpath:assets/textures/cute_image.png",
+        "shader": "default",
+        "wrapping": {
+            "u": "REPEAT",
+            "v": "REPEAT"
+        },
+        "filtering": {
+            "min": "MIPMAP_LINEAR_LINEAR",
+            "mag": "LINEAR"
+        }
+    },
+    "schema_version": 1
+}


### PR DESCRIPTION
1. feat: add feature to define concrete source for renderable textures instead of hard-linking by its asset id