### PR TITLE
[#265] Feat: add forward asset typedef passing to asset loader

### DIFF
--- a/components/component-entity/src/main/java/io/github/darthakiranihil/konna/entity/KEntityComponent.java
+++ b/components/component-entity/src/main/java/io/github/darthakiranihil/konna/entity/KEntityComponent.java
@@ -263,11 +263,4 @@ public class KEntityComponent extends KComponent {
         this.config = config;
     }
 
-    @Override
-    public KAssetTypedef[] getAssetTypedefs() {
-        return new KAssetTypedef[] {
-            new KEntityMetadataTypedef()
-        };
-    }
-
 }

--- a/components/component-entity/src/main/java/io/github/darthakiranihil/konna/entity/KEntityComponent.java
+++ b/components/component-entity/src/main/java/io/github/darthakiranihil/konna/entity/KEntityComponent.java
@@ -237,6 +237,12 @@ import io.github.darthakiranihil.konna.entity.type.KEntityMetadataTypedef;
  */
 public class KEntityComponent extends KComponent {
 
+    public static KAssetTypedef[] getAssetTypedefs2() {
+        return new KAssetTypedef[] {
+            new KEntityMetadataTypedef()
+        };
+    }
+
     /**
      * Component's config.
      */

--- a/components/component-entity/src/main/java/io/github/darthakiranihil/konna/entity/KEntityComponent.java
+++ b/components/component-entity/src/main/java/io/github/darthakiranihil/konna/entity/KEntityComponent.java
@@ -237,7 +237,10 @@ import io.github.darthakiranihil.konna.entity.type.KEntityMetadataTypedef;
  */
 public class KEntityComponent extends KComponent {
 
-    public static KAssetTypedef[] getAssetTypedefs2() {
+    /**
+     * @return Asset typedefs provided by this component
+     */
+    public static KAssetTypedef[] getAssetTypedefs() {
         return new KAssetTypedef[] {
             new KEntityMetadataTypedef()
         };

--- a/components/component-entity/src/test/java/io/github/darthakiranihil/konna/entity/asset/KAssetCollectionTestClass.java
+++ b/components/component-entity/src/test/java/io/github/darthakiranihil/konna/entity/asset/KAssetCollectionTestClass.java
@@ -42,7 +42,7 @@ public class KAssetCollectionTestClass extends KStandardTestClass {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][]{
-                KEntityComponent.getAssetTypedefs2()
+                KEntityComponent.getAssetTypedefs()
             }
         );
     }

--- a/components/component-entity/src/test/java/io/github/darthakiranihil/konna/entity/asset/KAssetCollectionTestClass.java
+++ b/components/component-entity/src/test/java/io/github/darthakiranihil/konna/entity/asset/KAssetCollectionTestClass.java
@@ -19,10 +19,11 @@ package io.github.darthakiranihil.konna.entity.asset;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.io.KAssetLoader;
+import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
 import io.github.darthakiranihil.konna.core.io.KStandardResourceLoader;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
-import io.github.darthakiranihil.konna.entity.type.KEntityMetadataTypedef;
+import io.github.darthakiranihil.konna.entity.KEntityComponent;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 
 import java.util.List;
@@ -39,9 +40,10 @@ public class KAssetCollectionTestClass extends KStandardTestClass {
                 List.of(new KClasspathProtocol(ClassLoader.getSystemClassLoader()))
             ),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][]{
+                KEntityComponent.getAssetTypedefs2()
+            }
         );
-
-        this.assetLoader.addAssetTypedef(new KEntityMetadataTypedef());
     }
 }

--- a/components/component-entity/src/test/java/io/github/darthakiranihil/konna/entity/modules/ContextModule.java
+++ b/components/component-entity/src/test/java/io/github/darthakiranihil/konna/entity/modules/ContextModule.java
@@ -20,16 +20,14 @@ import io.github.darthakiranihil.konna.core.app.*;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.*;
-import io.github.darthakiranihil.konna.core.io.KAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KResourceLoader;
-import io.github.darthakiranihil.konna.core.io.KStandardResourceLoader;
+import io.github.darthakiranihil.konna.core.io.*;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
 import io.github.darthakiranihil.konna.core.message.*;
 import io.github.darthakiranihil.konna.core.object.KActivator;
 import io.github.darthakiranihil.konna.core.object.KObjectRegistry;
 import io.github.darthakiranihil.konna.core.object.KStandardActivator;
 import io.github.darthakiranihil.konna.core.object.KStandardObjectRegistry;
+import io.github.darthakiranihil.konna.entity.KEntityComponent;
 import io.github.darthakiranihil.konna.test.KTestFrame;
 import org.jspecify.annotations.NonNull;
 
@@ -94,7 +92,10 @@ public class ContextModule extends KAbstractModule {
         return new KJsonAssetLoader(
             this.appContainer.getInstanceInferred(KResourceLoader.class),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][]{
+                KEntityComponent.getAssetTypedefs2()
+            }
         );
     }
 

--- a/components/component-entity/src/test/java/io/github/darthakiranihil/konna/entity/modules/ContextModule.java
+++ b/components/component-entity/src/test/java/io/github/darthakiranihil/konna/entity/modules/ContextModule.java
@@ -94,7 +94,7 @@ public class ContextModule extends KAbstractModule {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][]{
-                KEntityComponent.getAssetTypedefs2()
+                KEntityComponent.getAssetTypedefs()
             }
         );
     }

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponent.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponent.java
@@ -88,7 +88,10 @@ import io.github.darthakiranihil.konna.graphics.type.*;
  */
 public class KGraphicsComponent extends KComponent {
 
-    public static KAssetTypedef[] getAssetTypedefs2() {
+    /**
+     * @return Asset typedefs provided by this component
+     */
+    public static KAssetTypedef[] getAssetTypedefs() {
         return new KAssetTypedef[] {
             new KShaderTypedef(),
             new KShaderProgramTypedef(),

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponent.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponent.java
@@ -120,18 +120,6 @@ public class KGraphicsComponent extends KComponent {
     }
 
     @Override
-    public KAssetTypedef[] getAssetTypedefs() {
-        return new KAssetTypedef[] {
-            new KShaderTypedef(),
-            new KShaderProgramTypedef(),
-            new KTextureTypedef(),
-            new KTiledFontTypedef(),
-            new KTextureSliceSetTypedef(),
-            new KRenderableTextureTypedef(),
-        };
-    }
-
-    @Override
     public void postInit() {
 
         KRenderFrontend rf = this.engineModule

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponent.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponent.java
@@ -88,6 +88,17 @@ import io.github.darthakiranihil.konna.graphics.type.*;
  */
 public class KGraphicsComponent extends KComponent {
 
+    public static KAssetTypedef[] getAssetTypedefs2() {
+        return new KAssetTypedef[] {
+            new KShaderTypedef(),
+            new KShaderProgramTypedef(),
+            new KTextureTypedef(),
+            new KTiledFontTypedef(),
+            new KTextureSliceSetTypedef(),
+            new KRenderableTextureTypedef(),
+        };
+    }
+
     /**
      * Component's config.
      */

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KAssetCollectionTestClass.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KAssetCollectionTestClass.java
@@ -39,7 +39,7 @@ public class KAssetCollectionTestClass extends KStandardTestClass {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][]{
-                KGraphicsComponent.getAssetTypedefs2()
+                KGraphicsComponent.getAssetTypedefs()
             }
         );
 

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KAssetCollectionTestClass.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KAssetCollectionTestClass.java
@@ -20,8 +20,9 @@ import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.KEngineModule;
 import io.github.darthakiranihil.konna.core.io.KAssetLoader;
+import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
-import io.github.darthakiranihil.konna.graphics.type.*;
+import io.github.darthakiranihil.konna.graphics.KGraphicsComponent;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 
 public class KAssetCollectionTestClass extends KStandardTestClass {
@@ -36,14 +37,11 @@ public class KAssetCollectionTestClass extends KStandardTestClass {
         this.assetLoader = new KJsonAssetLoader(
             this.engineModule.resourceLoader(),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][]{
+                KGraphicsComponent.getAssetTypedefs2()
+            }
         );
 
-        this.assetLoader.addAssetTypedef(new KShaderTypedef());
-        this.assetLoader.addAssetTypedef(new KShaderProgramTypedef());
-        this.assetLoader.addAssetTypedef(new KTextureTypedef());
-        this.assetLoader.addAssetTypedef(new KTiledFontTypedef());
-        this.assetLoader.addAssetTypedef(new KTextureSliceSetTypedef());
-        this.assetLoader.addAssetTypedef(new KRenderableTextureTypedef());
     }
 }

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/modules/ContextModule.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/modules/ContextModule.java
@@ -84,7 +84,7 @@ public class ContextModule extends KAbstractModule {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "/dev/null" },
             new KAssetTypedef[][]{
-                KGraphicsComponent.getAssetTypedefs2()
+                KGraphicsComponent.getAssetTypedefs()
             }
         );
     }

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/modules/ContextModule.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/modules/ContextModule.java
@@ -20,10 +20,7 @@ import io.github.darthakiranihil.konna.core.app.*;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.*;
-import io.github.darthakiranihil.konna.core.io.KAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KResourceLoader;
-import io.github.darthakiranihil.konna.core.io.KStandardResourceLoader;
+import io.github.darthakiranihil.konna.core.io.*;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
 import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KMessageSystem;
@@ -33,6 +30,7 @@ import io.github.darthakiranihil.konna.core.object.KActivator;
 import io.github.darthakiranihil.konna.core.object.KObjectRegistry;
 import io.github.darthakiranihil.konna.core.object.KStandardActivator;
 import io.github.darthakiranihil.konna.core.object.KStandardObjectRegistry;
+import io.github.darthakiranihil.konna.graphics.KGraphicsComponent;
 
 import java.util.List;
 
@@ -84,7 +82,10 @@ public class ContextModule extends KAbstractModule {
         return new KJsonAssetLoader(
             this.appContainer.getInstanceInferred(KResourceLoader.class),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "/dev/null" }
+            new String[] { "/dev/null" },
+            new KAssetTypedef[][]{
+                KGraphicsComponent.getAssetTypedefs2()
+            }
         );
     }
 

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/KLevelComponent.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/KLevelComponent.java
@@ -450,6 +450,15 @@ import io.github.darthakiranihil.konna.level.type.KTileTypedef;
 @KSingleton
 public class KLevelComponent extends KComponent {
 
+    public static KAssetTypedef[] getAssetTypedefs2() {
+        return new KAssetTypedef[] {
+            new KTilePropertyTypedef(),
+            new KTileTypedef(),
+            new KLevelMetadataTypedef(),
+            new KLevelGeneratorMetadataTypedef()
+        };
+    }
+
     /**
      * Component's configuration.
      */

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/KLevelComponent.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/KLevelComponent.java
@@ -481,14 +481,4 @@ public class KLevelComponent extends KComponent {
         this.config = config;
     }
 
-    @Override
-    public KAssetTypedef[] getAssetTypedefs() {
-        return new KAssetTypedef[] {
-            new KTilePropertyTypedef(),
-            new KTileTypedef(),
-            new KLevelMetadataTypedef(),
-            new KLevelGeneratorMetadataTypedef()
-        };
-    }
-
 }

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/KLevelComponent.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/KLevelComponent.java
@@ -450,7 +450,10 @@ import io.github.darthakiranihil.konna.level.type.KTileTypedef;
 @KSingleton
 public class KLevelComponent extends KComponent {
 
-    public static KAssetTypedef[] getAssetTypedefs2() {
+    /**
+     * @return Asset typedefs provided by this component
+     */
+    public static KAssetTypedef[] getAssetTypedefs() {
         return new KAssetTypedef[] {
             new KTilePropertyTypedef(),
             new KTileTypedef(),

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/asset/KAssetCollectionTestClass.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/asset/KAssetCollectionTestClass.java
@@ -20,7 +20,9 @@ import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.KEngineModule;
 import io.github.darthakiranihil.konna.core.io.KAssetLoader;
+import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
+import io.github.darthakiranihil.konna.level.KLevelComponent;
 import io.github.darthakiranihil.konna.level.type.KLevelGeneratorMetadataTypedef;
 import io.github.darthakiranihil.konna.level.type.KLevelMetadataTypedef;
 import io.github.darthakiranihil.konna.level.type.KTilePropertyTypedef;
@@ -39,12 +41,11 @@ public class KAssetCollectionTestClass extends KStandardTestClass {
         this.assetLoader = new KJsonAssetLoader(
             this.engineModule.resourceLoader(),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][] {
+                KLevelComponent.getAssetTypedefs2()
+            }
         );
 
-        this.assetLoader.addAssetTypedef(new KTilePropertyTypedef());
-        this.assetLoader.addAssetTypedef(new KTileTypedef());
-        this.assetLoader.addAssetTypedef(new KLevelMetadataTypedef());
-        this.assetLoader.addAssetTypedef(new KLevelGeneratorMetadataTypedef());
     }
 }

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/asset/KAssetCollectionTestClass.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/asset/KAssetCollectionTestClass.java
@@ -23,10 +23,6 @@ import io.github.darthakiranihil.konna.core.io.KAssetLoader;
 import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
 import io.github.darthakiranihil.konna.level.KLevelComponent;
-import io.github.darthakiranihil.konna.level.type.KLevelGeneratorMetadataTypedef;
-import io.github.darthakiranihil.konna.level.type.KLevelMetadataTypedef;
-import io.github.darthakiranihil.konna.level.type.KTilePropertyTypedef;
-import io.github.darthakiranihil.konna.level.type.KTileTypedef;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 
 public class KAssetCollectionTestClass extends KStandardTestClass {
@@ -43,7 +39,7 @@ public class KAssetCollectionTestClass extends KStandardTestClass {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][] {
-                KLevelComponent.getAssetTypedefs2()
+                KLevelComponent.getAssetTypedefs()
             }
         );
 

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestLevelNode.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestLevelNode.java
@@ -20,6 +20,7 @@ import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.KInject;
+import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
 import io.github.darthakiranihil.konna.core.io.KResourceLoader;
 import io.github.darthakiranihil.konna.core.message.KEvent;
@@ -27,20 +28,13 @@ import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KStandardEventSystem;
 import io.github.darthakiranihil.konna.core.object.KActivator;
 import io.github.darthakiranihil.konna.core.util.KHashMapBasedCache;
-import io.github.darthakiranihil.konna.level.KLevel;
-import io.github.darthakiranihil.konna.level.KLevelLoader;
-import io.github.darthakiranihil.konna.level.KLevelSector;
-import io.github.darthakiranihil.konna.level.KStandardLevelLoader;
+import io.github.darthakiranihil.konna.level.*;
 import io.github.darthakiranihil.konna.level.asset.KLevelMetadataCollection;
 import io.github.darthakiranihil.konna.level.asset.KTileCollection;
 import io.github.darthakiranihil.konna.level.asset.KTilePropertyCollection;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNode;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeInputParam;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeOutputParam;
-import io.github.darthakiranihil.konna.level.type.KLevelGeneratorMetadataTypedef;
-import io.github.darthakiranihil.konna.level.type.KLevelMetadataTypedef;
-import io.github.darthakiranihil.konna.level.type.KTilePropertyTypedef;
-import io.github.darthakiranihil.konna.level.type.KTileTypedef;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Random;
@@ -60,13 +54,11 @@ public class TestLevelNode implements KGeneratorNode {
         var assetLoader = new KJsonAssetLoader(
             resourceLoader,
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][] {
+                KLevelComponent.getAssetTypedefs2()
+            }
         );
-
-        assetLoader.addAssetTypedef(new KTilePropertyTypedef());
-        assetLoader.addAssetTypedef(new KTileTypedef());
-        assetLoader.addAssetTypedef(new KLevelMetadataTypedef());
-        assetLoader.addAssetTypedef(new KLevelGeneratorMetadataTypedef());
 
         KEventSystem es = new KStandardEventSystem();
         es.registerEvent(new KEvent<KLevelSector.EventData>("entityMoved"));

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestLevelNode.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestLevelNode.java
@@ -56,7 +56,7 @@ public class TestLevelNode implements KGeneratorNode {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][] {
-                KLevelComponent.getAssetTypedefs2()
+                KLevelComponent.getAssetTypedefs()
             }
         );
 

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestUnvalidatedInputLevelNode.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestUnvalidatedInputLevelNode.java
@@ -20,6 +20,7 @@ import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.KInject;
+import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
 import io.github.darthakiranihil.konna.core.io.KResourceLoader;
 import io.github.darthakiranihil.konna.core.message.KEvent;
@@ -27,19 +28,12 @@ import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KStandardEventSystem;
 import io.github.darthakiranihil.konna.core.object.KActivator;
 import io.github.darthakiranihil.konna.core.util.KHashMapBasedCache;
-import io.github.darthakiranihil.konna.level.KLevel;
-import io.github.darthakiranihil.konna.level.KLevelLoader;
-import io.github.darthakiranihil.konna.level.KLevelSector;
-import io.github.darthakiranihil.konna.level.KStandardLevelLoader;
+import io.github.darthakiranihil.konna.level.*;
 import io.github.darthakiranihil.konna.level.asset.KLevelMetadataCollection;
 import io.github.darthakiranihil.konna.level.asset.KTileCollection;
 import io.github.darthakiranihil.konna.level.asset.KTilePropertyCollection;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNode;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeOutputParam;
-import io.github.darthakiranihil.konna.level.type.KLevelGeneratorMetadataTypedef;
-import io.github.darthakiranihil.konna.level.type.KLevelMetadataTypedef;
-import io.github.darthakiranihil.konna.level.type.KTilePropertyTypedef;
-import io.github.darthakiranihil.konna.level.type.KTileTypedef;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Random;
@@ -59,13 +53,11 @@ public class TestUnvalidatedInputLevelNode implements KGeneratorNode {
         var assetLoader = new KJsonAssetLoader(
             resourceLoader,
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][] {
+                KLevelComponent.getAssetTypedefs2()
+            }
         );
-
-        assetLoader.addAssetTypedef(new KTilePropertyTypedef());
-        assetLoader.addAssetTypedef(new KTileTypedef());
-        assetLoader.addAssetTypedef(new KLevelMetadataTypedef());
-        assetLoader.addAssetTypedef(new KLevelGeneratorMetadataTypedef());
 
         KEventSystem es = new KStandardEventSystem();
         es.registerEvent(new KEvent<KLevelSector.EventData>("entityMoved"));

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestUnvalidatedInputLevelNode.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestUnvalidatedInputLevelNode.java
@@ -55,7 +55,7 @@ public class TestUnvalidatedInputLevelNode implements KGeneratorNode {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][] {
-                KLevelComponent.getAssetTypedefs2()
+                KLevelComponent.getAssetTypedefs()
             }
         );
 

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/modules/ContextModule.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/modules/ContextModule.java
@@ -20,10 +20,7 @@ import io.github.darthakiranihil.konna.core.app.*;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.*;
-import io.github.darthakiranihil.konna.core.io.KAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KResourceLoader;
-import io.github.darthakiranihil.konna.core.io.KStandardResourceLoader;
+import io.github.darthakiranihil.konna.core.io.*;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
 import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KMessageSystem;
@@ -32,6 +29,7 @@ import io.github.darthakiranihil.konna.core.object.KActivator;
 import io.github.darthakiranihil.konna.core.object.KObjectRegistry;
 import io.github.darthakiranihil.konna.core.object.KStandardActivator;
 import io.github.darthakiranihil.konna.core.object.KStandardObjectRegistry;
+import io.github.darthakiranihil.konna.level.KLevelComponent;
 import io.github.darthakiranihil.konna.test.KSynchronousMessageSystem;
 
 import java.util.List;
@@ -84,7 +82,10 @@ public class ContextModule extends KAbstractModule {
         return new KJsonAssetLoader(
             this.appContainer.getInstanceInferred(KResourceLoader.class),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][] {
+                KLevelComponent.getAssetTypedefs2()
+            }
         );
     }
 

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/modules/ContextModule.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/modules/ContextModule.java
@@ -84,7 +84,7 @@ public class ContextModule extends KAbstractModule {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][] {
-                KLevelComponent.getAssetTypedefs2()
+                KLevelComponent.getAssetTypedefs()
             }
         );
     }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/engine/KComponent.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/engine/KComponent.java
@@ -19,7 +19,6 @@ package io.github.darthakiranihil.konna.core.engine;
 import io.github.darthakiranihil.konna.core.di.KEngineModule;
 import io.github.darthakiranihil.konna.core.engine.except.KEndpointRoutingException;
 import io.github.darthakiranihil.konna.core.except.KException;
-import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.log.system.KSystemLogger;
 import io.github.darthakiranihil.konna.core.message.KMessage;
 import io.github.darthakiranihil.konna.core.object.KActivator;
@@ -132,12 +131,6 @@ public abstract class KComponent extends KObject {
             );
         }
     }
-
-    /**
-     * Returns asset type definitions of that types that are internal for its component.
-     * @return Array of asset type definitions, used inside this component
-     */
-    public abstract KAssetTypedef[] getAssetTypedefs();
 
     /**
      * Runs post-init operations for this component. By default, the method does nothing

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/engine/KEngineHypervisor.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/engine/KEngineHypervisor.java
@@ -23,11 +23,12 @@ import io.github.darthakiranihil.konna.core.di.KAppContainer;
 import io.github.darthakiranihil.konna.core.di.KEngineModule;
 import io.github.darthakiranihil.konna.core.engine.except.KHypervisorInitializationException;
 import io.github.darthakiranihil.konna.core.except.KException;
-import io.github.darthakiranihil.konna.core.io.KAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.log.system.KSystemLogger;
 import io.github.darthakiranihil.konna.core.message.*;
-import io.github.darthakiranihil.konna.core.object.*;
+import io.github.darthakiranihil.konna.core.object.KActivator;
+import io.github.darthakiranihil.konna.core.object.KDefaultTags;
+import io.github.darthakiranihil.konna.core.object.KObject;
+import io.github.darthakiranihil.konna.core.object.KObjectRegistry;
 import io.github.darthakiranihil.konna.core.struct.ref.KLongReference;
 import io.github.darthakiranihil.konna.core.util.KClasspathSearchEngine;
 import io.github.darthakiranihil.konna.core.util.KReflectionUtils;
@@ -124,10 +125,6 @@ public class KEngineHypervisor extends KObject {
      *             KSystemFeatures, KActivator, KObjectRegistry, List) loading components}
      *         </li>
      *         <li>
-     *             {@link KEngineHypervisor#addAssetTypedefs(KAssetLoader, Map)
-     *             adding asset typedefs} to {@link KAssetLoader}
-     *         </li>
-     *         <li>
      *             {@link
      *             KEngineHypervisor#configureMessageRoutes(KActivator, KMessageSystem, Map, List)
      *             configuring message routes
@@ -193,9 +190,6 @@ public class KEngineHypervisor extends KObject {
 
         this.engineComponents.putAll(loadedComponents);
 
-
-        KAssetLoader assetLoader = engineModule.assetLoader();
-        this.addAssetTypedefs(assetLoader, loadedComponents);
         KMessageSystem messageSystem = engineModule.messageSystem();
         this.configureMessageRoutes(
             activator,
@@ -553,33 +547,6 @@ public class KEngineHypervisor extends KObject {
         KSystemLogger.info(
             this.name, "Executed %d message route configurers", configurers.size()
         );
-    }
-
-    /**
-     * Adds all asset typedefs, provided by all components, to current asset loader.
-     * @param assetLoader Asset loader to add the typedefs
-     * @param loadedComponents Map of loaded components
-     *
-     * @since 0.6.0
-     */
-    protected void addAssetTypedefs(
-        final KAssetLoader assetLoader,
-        final Map<String, KComponent> loadedComponents
-    ) {
-
-        for (KComponent component: loadedComponents.values()) {
-            KSystemLogger.debug(
-                this.name,
-                "Adding asset typedefs of %s",
-                component.getClass().getSimpleName()
-            );
-
-            KAssetTypedef[] assetTypedefs = component.getAssetTypedefs();
-            for (var typedef: assetTypedefs) {
-                assetLoader.addAssetTypedef(typedef);
-            }
-        }
-
     }
 
     /**

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/io/KAssetLoader.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/io/KAssetLoader.java
@@ -22,13 +22,6 @@ public interface KAssetLoader {
     KAsset loadAsset(String assetId, String typeAlias);
 
     /**
-     * Adds a new asset type definition to this loader.
-     * @param typedef Asset type definition
-     */
-    @Deprecated(forRemoval = true)
-    void addAssetTypedef(KAssetTypedef typedef);
-
-    /**
      * Add a new asset so that could be loaded by other components at request.
      * @param asset Asset to add
      */

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/io/KAssetLoader.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/io/KAssetLoader.java
@@ -25,6 +25,7 @@ public interface KAssetLoader {
      * Adds a new asset type definition to this loader.
      * @param typedef Asset type definition
      */
+    @Deprecated(forRemoval = true)
     void addAssetTypedef(KAssetTypedef typedef);
 
     /**

--- a/core/src/test/java/io/github/darthakiranihil/konna/core/engine/TestComponent.java
+++ b/core/src/test/java/io/github/darthakiranihil/konna/core/engine/TestComponent.java
@@ -31,8 +31,4 @@ public class TestComponent extends KComponent {
         super("TestComponent", engineModule, new KService[]{ testService });
     }
 
-    @Override
-    public KAssetTypedef[] getAssetTypedefs() {
-        return new KAssetTypedef[0];
-    }
 }

--- a/core/src/test/java/io/github/darthakiranihil/konna/core/engine/TestComponentAgain.java
+++ b/core/src/test/java/io/github/darthakiranihil/konna/core/engine/TestComponentAgain.java
@@ -30,8 +30,4 @@ public class TestComponentAgain extends KComponent {
         super("TestComponentAgain", engineModule, new KService[]{ anotherService });
     }
 
-    @Override
-    public KAssetTypedef[] getAssetTypedefs() {
-        return new KAssetTypedef[0];
-    }
 }

--- a/core/src/test/java/io/github/darthakiranihil/konna/core/modules/ContextModule.java
+++ b/core/src/test/java/io/github/darthakiranihil/konna/core/modules/ContextModule.java
@@ -20,10 +20,7 @@ import io.github.darthakiranihil.konna.core.app.*;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.*;
-import io.github.darthakiranihil.konna.core.io.KAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KResourceLoader;
-import io.github.darthakiranihil.konna.core.io.KStandardResourceLoader;
+import io.github.darthakiranihil.konna.core.io.*;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
 import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KMessageSystem;
@@ -85,7 +82,8 @@ public class ContextModule extends KAbstractModule {
         return new KJsonAssetLoader(
             this.appContainer.getInstanceInferred(KResourceLoader.class),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "/dev/null" }
+            new String[] { "/dev/null" },
+            new KAssetTypedef[0][0]
         );
     }
 

--- a/implementations/implementations-std-core/src/main/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoader.java
+++ b/implementations/implementations-std-core/src/main/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoader.java
@@ -153,20 +153,6 @@ public class KJsonAssetLoader
     }
 
     @Override
-    public void addAssetTypedef(final KAssetTypedef typedef) {
-        this.assetTypedefs.put(typedef.getName(), typedef);
-
-        KAssetDefinitionRule rule = typedef.getRule();
-        String typeName = typedef.getName();
-
-        for (KAsset asset : this.loadedAssets.values()) {
-            if (asset.getType().equals(typeName)) {
-                rule.validate(asset);
-            }
-        }
-    }
-
-    @Override
     public void addNewAsset(
         final KAsset asset
     ) {

--- a/implementations/implementations-std-core/src/main/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoader.java
+++ b/implementations/implementations-std-core/src/main/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoader.java
@@ -90,6 +90,25 @@ public class KJsonAssetLoader
         protected abstract KAsset constructAsset(KAssetDefinition definition);
     }
 
+    private static Map<String, KAssetTypedef> validateTypedefs(final KAssetTypedef[][] typedefs) {
+        Map<String, KAssetTypedef> validated = new HashMap<>(typedefs.length);
+        for (KAssetTypedef[] group: typedefs) {
+            for (KAssetTypedef typedef : group) {
+                String typeName = typedef.getName();
+                if (validated.containsKey(typeName)) {
+                    throw new KInvalidArgumentException(String.format(
+                        "Duplicate asset typedefs found: %s",
+                        typeName
+                    ));
+                }
+
+                validated.put(typeName, typedef);
+            }
+        }
+
+        return validated;
+    }
+
     private final Map<String, KAsset> loadedAssets;
     private final Map<String, KAssetTypedef> assetTypedefs;
 
@@ -103,65 +122,14 @@ public class KJsonAssetLoader
     public KJsonAssetLoader(
         final KResourceLoader resourceLoader,
         final KJsonParser jsonParser,
-        final String[] pathsToAssets
+        final String[] pathsToAssets,
+        final KAssetTypedef[][] assetTypedefs
     ) {
         super("JsonAssetLoader", Set.of(KDefaultTags.STD, KDefaultTags.SYSTEM));
 
+        this.assetTypedefs = KJsonAssetLoader.validateTypedefs(assetTypedefs);
         this.loadedAssets = new HashMap<>();
-
-        int loadedAssetsCount = 0;
-
-        for (String pathToAssets : pathsToAssets) {
-            KResource[] assetsResources = resourceLoader.loadResources(pathToAssets, true);
-            for (KResource assetResource : assetsResources) {
-                if (!assetResource.name().endsWith(".json")) {
-                    assetResource.close();
-                    continue;
-                }
-
-                try (assetResource) {
-                    InputStream stream = assetResource.stream();
-                    if (stream == null) {
-                        throw new KAssetLoadingException(
-                            String.format(
-                                "Cannot read stream from asset resource %s",
-                                assetResource.name()
-                            )
-                        );
-                    }
-
-                    KJsonValue jsonDefinition = jsonParser.parse(stream);
-                    KAssetDefinition def = new KJsonAssetDefinition(jsonDefinition);
-                    if (!def.hasInt("schema_version")) {
-                        throw new KAssetLoadingException(
-                            String.format(
-                                "Could not read metafile schema version of %s",
-                                assetResource.name()
-                            )
-                        );
-                    }
-
-                    int schemaVersionValue = def.getInt("schema_version");
-                    SchemaVersion schemaVersion = SchemaVersion.getSchemaVersion(
-                        schemaVersionValue
-                    );
-                    KAsset loaded = schemaVersion.makeAsset(def);
-                    if (this.loadedAssets.containsKey(loaded.getId())) {
-                        throw new KAssetLoadingException(String.format(
-                            "Cannot load asset with id %s: asset id is not unique",
-                            loaded.getId()
-                        ));
-                    }
-
-                    this.loadedAssets.put(loaded.getId(), loaded);
-                    loadedAssetsCount++;
-                }
-            }
-        }
-
-        KSystemLogger.info(this.name, "Loaded %d assets", loadedAssetsCount);
-
-        this.assetTypedefs = new HashMap<>();
+        this.loadAssetsFromPaths(pathsToAssets, resourceLoader, jsonParser);
 
     }
 
@@ -223,6 +191,76 @@ public class KJsonAssetLoader
         }
 
         this.loadedAssets.put(assetId, asset);
+    }
+
+    private void loadAssetsFromPaths(
+        final String[] pathsToAssets,
+        final KResourceLoader resourceLoader,
+        final KJsonParser jsonParser
+    ) {
+        int loadedAssetsCount = 0;
+
+        for (String pathToAssets : pathsToAssets) {
+            KResource[] assetsResources = resourceLoader.loadResources(pathToAssets, true);
+            for (KResource assetResource : assetsResources) {
+                if (!assetResource.name().endsWith(".json")) {
+                    assetResource.close();
+                    continue;
+                }
+
+                try (assetResource) {
+                    InputStream stream = assetResource.stream();
+                    if (stream == null) {
+                        throw new KAssetLoadingException(
+                            String.format(
+                                "Cannot read stream from asset resource %s",
+                                assetResource.name()
+                            )
+                        );
+                    }
+
+                    KJsonValue jsonDefinition = jsonParser.parse(stream);
+                    KAssetDefinition def = new KJsonAssetDefinition(jsonDefinition);
+                    if (!def.hasInt("schema_version")) {
+                        throw new KAssetLoadingException(
+                            String.format(
+                                "Could not read metafile schema version of %s",
+                                assetResource.name()
+                            )
+                        );
+                    }
+
+                    int schemaVersionValue = def.getInt("schema_version");
+                    SchemaVersion schemaVersion = SchemaVersion.getSchemaVersion(
+                        schemaVersionValue
+                    );
+                    KAsset loaded = schemaVersion.makeAsset(def);
+                    if (this.loadedAssets.containsKey(loaded.getId())) {
+                        throw new KAssetLoadingException(String.format(
+                            "Cannot load asset with id %s: asset id is not unique",
+                            loaded.getId()
+                        ));
+                    }
+
+                    String type = loaded.getType();
+                    if (!this.assetTypedefs.containsKey(type)) {
+                        throw new KAssetLoadingException(
+                            String.format(
+                                "Cannot load asset with id %s. Unknown type: %s",
+                                loaded.getId(),
+                                type
+                            )
+                        );
+                    }
+
+                    this.assetTypedefs.get(type).getRule().validate(loaded);
+                    this.loadedAssets.put(loaded.getId(), loaded);
+                    loadedAssetsCount++;
+                }
+            }
+        }
+
+        KSystemLogger.info(this.name, "Loaded %d assets", loadedAssetsCount);
     }
 
 }

--- a/implementations/implementations-std-core/src/main/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoader.java
+++ b/implementations/implementations-std-core/src/main/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoader.java
@@ -118,6 +118,8 @@ public class KJsonAssetLoader
      * @param resourceLoader Resource loader (to load JSON files)
      * @param jsonParser     JSON parser to parse loaded definitions
      * @param pathsToAssets  Paths to directories to look definitions in
+     * @param assetTypedefs Types of assets that are valid for this asset loader (unknown types
+     *                      will raise an error)
      */
     public KJsonAssetLoader(
         final KResourceLoader resourceLoader,

--- a/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/engine/TestComponent.java
+++ b/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/engine/TestComponent.java
@@ -31,8 +31,4 @@ public class TestComponent extends KComponent {
         super("TestComponent", engineModule, new KService[]{ testService });
     }
 
-    @Override
-    public KAssetTypedef[] getAssetTypedefs() {
-        return new KAssetTypedef[0];
-    }
 }

--- a/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/engine/TestComponentAgain.java
+++ b/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/engine/TestComponentAgain.java
@@ -32,8 +32,4 @@ public class TestComponentAgain extends KComponent {
         super("TestComponentAgain", engineModule, new KService[]{ anotherService });
     }
 
-    @Override
-    public KAssetTypedef[] getAssetTypedefs() {
-        return new KAssetTypedef[0];
-    }
 }

--- a/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoaderNegativeTests.java
+++ b/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoaderNegativeTests.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.core.io;
 
 import io.github.darthakiranihil.konna.core.data.json.KJsonValue;
+import io.github.darthakiranihil.konna.core.io.except.KAssetDefinitionError;
 import io.github.darthakiranihil.konna.core.io.except.KAssetLoadingException;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
@@ -33,7 +34,7 @@ public class KJsonAssetLoaderNegativeTests extends KStandardTestClass {
 
         @Override
         public String getName() {
-            return "alias_1";
+            return "type_1";
         }
 
         @Override
@@ -113,13 +114,44 @@ public class KJsonAssetLoaderNegativeTests extends KStandardTestClass {
             );
 
             Assertions.assertThrows(
-                KAssetLoadingException.class,
+                KAssetDefinitionError.class,
                 () -> assetLoader.addNewAsset(new KAsset("type_1.asset_2", "type_1", new KJsonAssetDefinition(addedDef, v -> {})))
             );
 
         } catch (Throwable e) {
             Assertions.fail(e);
         }
+
+    }
+
+    @Test
+    public void testAddAssetTypeDefinitionThatIsNotRegistered() {
+
+        Assertions.assertThrows(
+            KAssetLoadingException.class,
+            () -> new KJsonAssetLoader(
+            new KStandardResourceLoader(
+                List.of(new KClasspathProtocol(
+                    ClassLoader.getSystemClassLoader()
+                ))
+            ),
+            this.jsonParser,
+            new String[] { "classpath:new_assets/" },
+            new KAssetTypedef[][]{
+                new KAssetTypedef[] { new KAssetTypedef() {
+                    @Override
+                    public String getName() {
+                        return "alias_16";
+                    }
+
+                    @Override
+                    public KAssetDefinitionRule getRule() {
+                        return KCompositeAssetDefinitionRuleBuilder
+                            .create().build();
+                    }
+                } }
+            }
+        ));
 
     }
 

--- a/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoaderNegativeTests.java
+++ b/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoaderNegativeTests.java
@@ -17,8 +17,6 @@
 package io.github.darthakiranihil.konna.core.io;
 
 import io.github.darthakiranihil.konna.core.data.json.KJsonValue;
-import io.github.darthakiranihil.konna.core.data.json.except.KJsonValidationError;
-import io.github.darthakiranihil.konna.core.io.except.KAssetDefinitionError;
 import io.github.darthakiranihil.konna.core.io.except.KAssetLoadingException;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
@@ -66,32 +64,13 @@ public class KJsonAssetLoaderNegativeTests extends KStandardTestClass {
                 ))
             ),
             this.jsonParser,
-            new String[] { "classpath:new_assets/" }
-//            new KJsonTransformerBasedAssetLoader.AssetTypeData(
-//                "type_1",
-//                Map.of(
-//                    "alias_1",
-//                    (v) -> {
-//                        Map<String, Object> data = new HashMap<>();
-//                        data.put("int_property", v.getInt("int_property"));
-//                        data.put("float_property", v.getFloat("float_property"));
-//                        data.put("boolean_property", v.getBoolean("boolean_property"));
-//                        data.put("string_property", v.getString("string_property"));
-//                        data.put("subdef_property", v.getSubdefinition("subdef_property"));
-//                        data.put("int_array_property", v.getIntArray("int_array_property"));
-//                        data.put("float_array_property", v.getFloatArray("float_array_property"));
-//                        data.put("boolean_array_property", v.getBooleanArray("boolean_array_property"));
-//                        data.put("string_array_property", v.getStringArray("string_array_property"));
-//                        data.put("subdef_array_property", v.getSubdefinitionArray("subdef_array_property"));
-//                        return new KMapAssetDefinition(data);
-//                    }
-//                )
-//            )
+            new String[] { "classpath:new_assets/" },
+            new KAssetTypedef[][]{
+                new KAssetTypedef[] { new KJsonAssetLoaderNegativeTests.Alias1Typedef() }
+            }
         );
 
         try {
-            assetLoader.addAssetTypedef(new KJsonAssetLoaderNegativeTests.Alias1Typedef());
-
             Assertions.assertThrows(
                 KAssetLoadingException.class,
                 () -> assetLoader.loadAsset("type_1.asset_1", "alias_2")
@@ -100,52 +79,6 @@ public class KJsonAssetLoaderNegativeTests extends KStandardTestClass {
         } catch (Throwable e) {
             Assertions.fail(e);
         }
-    }
-
-    @Test
-    public void testAddAssetTypeAliasInvalidAsset() {
-
-        KAssetLoader assetLoader = new KJsonAssetLoader(
-            new KStandardResourceLoader(
-                List.of(new KClasspathProtocol(
-                    ClassLoader.getSystemClassLoader()
-                ))
-            ),
-            this.jsonParser,
-            new String[] {  "classpath:invalid_new_assets/" }
-//            new KJsonTransformerBasedAssetLoader.AssetTypeData(
-//                "type_1",
-//                Map.of(
-//                    "alias_1",
-//                    (v) -> {
-//                        Map<String, Object> data = new HashMap<>();
-//                        data.put("int_property", v.getInt("int_property"));
-//                        data.put("float_property", v.getFloat("float_property"));
-//                        data.put("boolean_property", v.getBoolean("boolean_property"));
-//                        data.put("string_property", v.getString("string_property"));
-//                        data.put("subdef_property", v.getSubdefinition("subdef_property"));
-//                        data.put("int_array_property", v.getIntArray("int_array_property"));
-//                        data.put("float_array_property", v.getFloatArray("float_array_property"));
-//                        data.put("boolean_array_property", v.getBooleanArray("boolean_array_property"));
-//                        data.put("string_array_property", v.getStringArray("string_array_property"));
-//                        data.put("subdef_array_property", v.getSubdefinitionArray("subdef_array_property"));
-//                        return new KMapAssetDefinition(data);
-//                    }
-//                )
-//            )
-        );
-
-        try {
-
-            Assertions.assertThrows(
-                KAssetDefinitionError.class,
-                () -> assetLoader.addAssetTypedef(new KJsonAssetLoaderNegativeTests.Alias1Typedef())
-            );
-
-        } catch (Throwable e) {
-            Assertions.fail(e);
-        }
-
     }
 
     @Test
@@ -158,32 +91,13 @@ public class KJsonAssetLoaderNegativeTests extends KStandardTestClass {
                 ))
             ),
             this.jsonParser,
-            new String[] { "classpath:new_assets/" }
-//            new KJsonTransformerBasedAssetLoader.AssetTypeData(
-//                "type_1",
-//                Map.of(
-//                    "alias_1",
-//                    (v) -> {
-//                        Map<String, Object> data = new HashMap<>();
-//                        data.put("int_property", v.getInt("int_property"));
-//                        data.put("float_property", v.getFloat("float_property"));
-//                        data.put("boolean_property", v.getBoolean("boolean_property"));
-//                        data.put("string_property", v.getString("string_property"));
-//                        data.put("subdef_property", v.getSubdefinition("subdef_property"));
-//                        data.put("int_array_property", v.getIntArray("int_array_property"));
-//                        data.put("float_array_property", v.getFloatArray("float_array_property"));
-//                        data.put("boolean_array_property", v.getBooleanArray("boolean_array_property"));
-//                        data.put("string_array_property", v.getStringArray("string_array_property"));
-//                        data.put("subdef_array_property", v.getSubdefinitionArray("subdef_array_property"));
-//                        return new KMapAssetDefinition(data);
-//                    }
-//                )
-//            )
+            new String[] { "classpath:new_assets/" },
+            new KAssetTypedef[][]{
+                new KAssetTypedef[] { new KJsonAssetLoaderNegativeTests.Alias1Typedef() }
+            }
         );
 
         try {
-            assetLoader.addAssetTypedef(new KJsonAssetLoaderNegativeTests.Alias1Typedef());
-
             KJsonValue addedDef = this.jsonParser.parse("""
                 {
                         "alias_1": {
@@ -219,31 +133,13 @@ public class KJsonAssetLoaderNegativeTests extends KStandardTestClass {
                 ))
             ),
             this.jsonParser,
-            new String[] { "classpath:new_assets/" }
-//            new KJsonTransformerBasedAssetLoader.AssetTypeData(
-//                "type_1",
-//                Map.of(
-//                    "alias_1",
-//                    (v) -> {
-//                        Map<String, Object> data = new HashMap<>();
-//                        data.put("int_property", v.getInt("int_property"));
-//                        data.put("float_property", v.getFloat("float_property"));
-//                        data.put("boolean_property", v.getBoolean("boolean_property"));
-//                        data.put("string_property", v.getString("string_property"));
-//                        data.put("subdef_property", v.getSubdefinition("subdef_property"));
-//                        data.put("int_array_property", v.getIntArray("int_array_property"));
-//                        data.put("float_array_property", v.getFloatArray("float_array_property"));
-//                        data.put("boolean_array_property", v.getBooleanArray("boolean_array_property"));
-//                        data.put("string_array_property", v.getStringArray("string_array_property"));
-//                        data.put("subdef_array_property", v.getSubdefinitionArray("subdef_array_property"));
-//                        return new KMapAssetDefinition(data);
-//                    }
-//                )
-//            )
+            new String[] { "classpath:new_assets/" },
+            new KAssetTypedef[][]{
+                new KAssetTypedef[] { new KJsonAssetLoaderNegativeTests.Alias1Typedef() }
+            }
         );
 
         try {
-            assetLoader.addAssetTypedef(new KJsonAssetLoaderNegativeTests.Alias1Typedef());
 
             KJsonValue addedDef = this.jsonParser.parse("""
                 {
@@ -286,27 +182,10 @@ public class KJsonAssetLoaderNegativeTests extends KStandardTestClass {
                         ))
                     ),
                     this.jsonParser,
-                    new String[] { "classpath:assets_with_non_unique/" }
-//                    new KJsonTransformerBasedAssetLoader.AssetTypeData(
-//                        "type_1",
-//                        Map.of(
-//                            "alias_1",
-//                            (v) -> {
-//                                Map<String, Object> data = new HashMap<>();
-//                                data.put("int_property", v.getInt("int_property"));
-//                                data.put("float_property", v.getFloat("float_property"));
-//                                data.put("boolean_property", v.getBoolean("boolean_property"));
-//                                data.put("string_property", v.getString("string_property"));
-//                                data.put("subdef_property", v.getSubdefinition("subdef_property"));
-//                                data.put("int_array_property", v.getIntArray("int_array_property"));
-//                                data.put("float_array_property", v.getFloatArray("float_array_property"));
-//                                data.put("boolean_array_property", v.getBooleanArray("boolean_array_property"));
-//                                data.put("string_array_property", v.getStringArray("string_array_property"));
-//                                data.put("subdef_array_property", v.getSubdefinitionArray("subdef_array_property"));
-//                                return new KMapAssetDefinition(data);
-//                            }
-//                        )
-//                    )
+                    new String[] { "classpath:assets_with_non_unique/" },
+                    new KAssetTypedef[][]{
+                        new KAssetTypedef[] { new KJsonAssetLoaderNegativeTests.Alias1Typedef() }
+                    }
                 )
             );
 
@@ -326,27 +205,10 @@ public class KJsonAssetLoaderNegativeTests extends KStandardTestClass {
                 ))
             ),
             this.jsonParser,
-            new String[] { "classpath:new_assets/" }
-//            new KJsonTransformerBasedAssetLoader.AssetTypeData(
-//                "type_1",
-//                Map.of(
-//                    "alias_1",
-//                    (v) -> {
-//                        Map<String, Object> data = new HashMap<>();
-//                        data.put("int_property", v.getInt("int_property"));
-//                        data.put("float_property", v.getFloat("float_property"));
-//                        data.put("boolean_property", v.getBoolean("boolean_property"));
-//                        data.put("string_property", v.getString("string_property"));
-//                        data.put("subdef_property", v.getSubdefinition("subdef_property"));
-//                        data.put("int_array_property", v.getIntArray("int_array_property"));
-//                        data.put("float_array_property", v.getFloatArray("float_array_property"));
-//                        data.put("boolean_array_property", v.getBooleanArray("boolean_array_property"));
-//                        data.put("string_array_property", v.getStringArray("string_array_property"));
-//                        data.put("subdef_array_property", v.getSubdefinitionArray("subdef_array_property"));
-//                        return new KMapAssetDefinition(data);
-//                    }
-//                )
-//            )
+            new String[] { "classpath:new_assets/" },
+            new KAssetTypedef[][]{
+                new KAssetTypedef[] { new KJsonAssetLoaderNegativeTests.Alias1Typedef() }
+            }
         );
 
         try {

--- a/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoaderPositiveTests.java
+++ b/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoaderPositiveTests.java
@@ -64,12 +64,13 @@ public class KJsonAssetLoaderPositiveTests extends KStandardTestClass {
                 ))
             ),
             this.jsonParser,
-            new String[] { "classpath:new_assets/" }
-
+            new String[] { "classpath:new_assets/" },
+            new KAssetTypedef[][] {
+                new KAssetTypedef[] { new Alias1Typedef() }
+            }
         );
 
         try {
-            assetLoader.addAssetTypedef(new KJsonAssetLoaderPositiveTests.Alias1Typedef());
 
             KAsset asset = assetLoader.loadAsset("type_1.asset_1", "type_1");
 
@@ -117,33 +118,29 @@ public class KJsonAssetLoaderPositiveTests extends KStandardTestClass {
     @Test
     public void testAddAssetTypeDefinitionThatIsNotRegistered() {
 
-        KAssetLoader assetLoader = new KJsonAssetLoader(
+        Assertions.assertDoesNotThrow(() -> new KJsonAssetLoader(
             new KStandardResourceLoader(
                 List.of(new KClasspathProtocol(
                     ClassLoader.getSystemClassLoader()
                 ))
             ),
             this.jsonParser,
-            new String[] { "classpath:new_assets/" }
-        );
+            new String[] { "classpath:new_assets/" },
+            new KAssetTypedef[][]{
+                new KAssetTypedef[] { new KAssetTypedef() {
+                    @Override
+                    public String getName() {
+                        return "alias_16";
+                    }
 
-        try {
-            assetLoader.addAssetTypedef(new KAssetTypedef() {
-                @Override
-                public String getName() {
-                    return "alias_16";
-                }
-
-                @Override
-                public KAssetDefinitionRule getRule() {
-                    return KCompositeAssetDefinitionRuleBuilder
-                        .create().build();
-                }
-            });
-
-        } catch (Throwable e) {
-            Assertions.fail(e);
-        }
+                    @Override
+                    public KAssetDefinitionRule getRule() {
+                        return KCompositeAssetDefinitionRuleBuilder
+                            .create().build();
+                    }
+                } }
+            }
+        ));
 
     }
 
@@ -157,32 +154,13 @@ public class KJsonAssetLoaderPositiveTests extends KStandardTestClass {
                 ))
             ),
             this.jsonParser,
-            new String[] { "classpath:new_assets/" }
-//            new KJsonTransformerBasedAssetLoader.AssetTypeData(
-//                "type_1",
-//                Map.of(
-//                    "alias_1",
-//                    (v) -> {
-//                        Map<String, Object> data = new HashMap<>();
-//                        data.put("int_property", v.getInt("int_property"));
-//                        data.put("float_property", v.getFloat("float_property"));
-//                        data.put("boolean_property", v.getBoolean("boolean_property"));
-//                        data.put("string_property", v.getString("string_property"));
-//                        data.put("subdef_property", v.getSubdefinition("subdef_property"));
-//                        data.put("int_array_property", v.getIntArray("int_array_property"));
-//                        data.put("float_array_property", v.getFloatArray("float_array_property"));
-//                        data.put("boolean_array_property", v.getBooleanArray("boolean_array_property"));
-//                        data.put("string_array_property", v.getStringArray("string_array_property"));
-//                        data.put("subdef_array_property", v.getSubdefinitionArray("subdef_array_property"));
-//                        return new KMapAssetDefinition(data);
-//                    }
-//                )
-//            )
+            new String[] { "classpath:new_assets/" },
+            new KAssetTypedef[][] {
+                new KAssetTypedef[] { new Alias1Typedef() }
+            }
         );
 
         try {
-            assetLoader.addAssetTypedef(new KJsonAssetLoaderPositiveTests.Alias1Typedef());
-
             KJsonValue addedDef = this.jsonParser.parse("""
                 {
                 "type": "type_1",

--- a/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoaderPositiveTests.java
+++ b/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/io/KJsonAssetLoaderPositiveTests.java
@@ -33,7 +33,7 @@ public class KJsonAssetLoaderPositiveTests extends KStandardTestClass {
 
         @Override
         public String getName() {
-            return "alias_1";
+            return "type_1";
         }
 
         @Override
@@ -116,35 +116,6 @@ public class KJsonAssetLoaderPositiveTests extends KStandardTestClass {
     }
 
     @Test
-    public void testAddAssetTypeDefinitionThatIsNotRegistered() {
-
-        Assertions.assertDoesNotThrow(() -> new KJsonAssetLoader(
-            new KStandardResourceLoader(
-                List.of(new KClasspathProtocol(
-                    ClassLoader.getSystemClassLoader()
-                ))
-            ),
-            this.jsonParser,
-            new String[] { "classpath:new_assets/" },
-            new KAssetTypedef[][]{
-                new KAssetTypedef[] { new KAssetTypedef() {
-                    @Override
-                    public String getName() {
-                        return "alias_16";
-                    }
-
-                    @Override
-                    public KAssetDefinitionRule getRule() {
-                        return KCompositeAssetDefinitionRuleBuilder
-                            .create().build();
-                    }
-                } }
-            }
-        ));
-
-    }
-
-    @Test
     public void testAddNewAsset() {
 
         KAssetLoader assetLoader = new KJsonAssetLoader(
@@ -203,8 +174,8 @@ public class KJsonAssetLoaderPositiveTests extends KStandardTestClass {
                     }"""
             );
 
-            assetLoader.addNewAsset(new KAsset("type_1.asset_2", "alias_1", new KJsonAssetDefinition(addedDef, v -> {})));
-            assetLoader.addNewAsset(new KAsset("type_1.asset_3", "alias_1", new KJsonAssetDefinition(addedDef, v -> {})));
+            assetLoader.addNewAsset(new KAsset("type_1.asset_2", "type_1", new KJsonAssetDefinition(addedDef, v -> {})));
+            assetLoader.addNewAsset(new KAsset("type_1.asset_3", "type_1", new KJsonAssetDefinition(addedDef, v -> {})));
 
         } catch (Throwable e) {
             Assertions.fail(e);

--- a/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/modules/ContextModule.java
+++ b/implementations/implementations-std-core/src/test/java/io/github/darthakiranihil/konna/core/modules/ContextModule.java
@@ -84,7 +84,8 @@ public class ContextModule extends KAbstractModule {
         return new KJsonAssetLoader(
             this.appContainer.getInstanceInferred(KResourceLoader.class),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "/dev/null" }
+            new String[] { "/dev/null" },
+            new KAssetTypedef[0][0]
         );
     }
 

--- a/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryNegativeTests.java
+++ b/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryNegativeTests.java
@@ -48,7 +48,6 @@ public class KStandardEntityFactoryNegativeTests extends KStandardTestClass {
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][]{ KEntityComponent.getAssetTypedefs2() }
         );
-        assetLoader.addAssetTypedef(new KEntityMetadataTypedef());
 
         var metadataCollection = new KEntityMetadataCollection(
             assetLoader

--- a/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryNegativeTests.java
+++ b/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryNegativeTests.java
@@ -15,7 +15,6 @@ import io.github.darthakiranihil.konna.core.util.KReflectionUtils;
 import io.github.darthakiranihil.konna.entity.asset.KEntityMetadataCollection;
 import io.github.darthakiranihil.konna.entity.except.KEntityException;
 import io.github.darthakiranihil.konna.entity.impl.TestEntityDataComponent;
-import io.github.darthakiranihil.konna.entity.type.KEntityMetadataTypedef;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -46,7 +45,7 @@ public class KStandardEntityFactoryNegativeTests extends KStandardTestClass {
             engineModule.resourceLoader(),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
-            new KAssetTypedef[][]{ KEntityComponent.getAssetTypedefs2() }
+            new KAssetTypedef[][]{ KEntityComponent.getAssetTypedefs() }
         );
 
         var metadataCollection = new KEntityMetadataCollection(

--- a/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryNegativeTests.java
+++ b/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryNegativeTests.java
@@ -9,6 +9,7 @@ import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.KAppContainer;
 import io.github.darthakiranihil.konna.core.di.KEngineModule;
+import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
 import io.github.darthakiranihil.konna.core.util.KReflectionUtils;
 import io.github.darthakiranihil.konna.entity.asset.KEntityMetadataCollection;
@@ -44,7 +45,8 @@ public class KStandardEntityFactoryNegativeTests extends KStandardTestClass {
         var assetLoader = new KJsonAssetLoader(
             engineModule.resourceLoader(),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][]{ KEntityComponent.getAssetTypedefs2() }
         );
         assetLoader.addAssetTypedef(new KEntityMetadataTypedef());
 

--- a/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryPositiveTests.java
+++ b/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryPositiveTests.java
@@ -65,7 +65,6 @@ public class KStandardEntityFactoryPositiveTests extends KStandardTestClass {
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][]{ KEntityComponent.getAssetTypedefs2() }
         );
-        assetLoader.addAssetTypedef(new KEntityMetadataTypedef());
 
         var metadataCollection = new KEntityMetadataCollection(
             assetLoader

--- a/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryPositiveTests.java
+++ b/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryPositiveTests.java
@@ -32,7 +32,6 @@ import io.github.darthakiranihil.konna.entity.impl.TestBehaviour;
 import io.github.darthakiranihil.konna.entity.impl.TestBehaviour2;
 import io.github.darthakiranihil.konna.entity.impl.TestEntityDataComponent;
 import io.github.darthakiranihil.konna.entity.impl.TestEntityDataComponent2;
-import io.github.darthakiranihil.konna.entity.type.KEntityMetadataTypedef;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -63,7 +62,7 @@ public class KStandardEntityFactoryPositiveTests extends KStandardTestClass {
             engineModule.resourceLoader(),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
-            new KAssetTypedef[][]{ KEntityComponent.getAssetTypedefs2() }
+            new KAssetTypedef[][]{ KEntityComponent.getAssetTypedefs() }
         );
 
         var metadataCollection = new KEntityMetadataCollection(

--- a/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryPositiveTests.java
+++ b/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/KStandardEntityFactoryPositiveTests.java
@@ -24,6 +24,7 @@ import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.KAppContainer;
 import io.github.darthakiranihil.konna.core.di.KEngineModule;
+import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
 import io.github.darthakiranihil.konna.core.util.KReflectionUtils;
 import io.github.darthakiranihil.konna.entity.asset.KEntityMetadataCollection;
@@ -61,7 +62,8 @@ public class KStandardEntityFactoryPositiveTests extends KStandardTestClass {
         var assetLoader = new KJsonAssetLoader(
             engineModule.resourceLoader(),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][]{ KEntityComponent.getAssetTypedefs2() }
         );
         assetLoader.addAssetTypedef(new KEntityMetadataTypedef());
 

--- a/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/modules/ContextModule.java
+++ b/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/modules/ContextModule.java
@@ -84,7 +84,7 @@ public class ContextModule extends KAbstractModule {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "/dev/null" },
             new KAssetTypedef[][]{
-                KEntityComponent.getAssetTypedefs2()
+                KEntityComponent.getAssetTypedefs()
             }
         );
     }

--- a/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/modules/ContextModule.java
+++ b/implementations/implementations-std-entity/src/test/java/io/github/darthakiranihil/konna/entity/modules/ContextModule.java
@@ -20,10 +20,7 @@ import io.github.darthakiranihil.konna.core.app.*;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.*;
-import io.github.darthakiranihil.konna.core.io.KAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KResourceLoader;
-import io.github.darthakiranihil.konna.core.io.KStandardResourceLoader;
+import io.github.darthakiranihil.konna.core.io.*;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
 import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KMessageSystem;
@@ -33,6 +30,7 @@ import io.github.darthakiranihil.konna.core.object.KActivator;
 import io.github.darthakiranihil.konna.core.object.KObjectRegistry;
 import io.github.darthakiranihil.konna.core.object.KStandardActivator;
 import io.github.darthakiranihil.konna.core.object.KStandardObjectRegistry;
+import io.github.darthakiranihil.konna.entity.KEntityComponent;
 
 import java.util.List;
 
@@ -84,7 +82,10 @@ public class ContextModule extends KAbstractModule {
         return new KJsonAssetLoader(
             this.appContainer.getInstanceInferred(KResourceLoader.class),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "/dev/null" }
+            new String[] { "/dev/null" },
+            new KAssetTypedef[][]{
+                KEntityComponent.getAssetTypedefs2()
+            }
         );
     }
 

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderNegativeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderNegativeTests.java
@@ -24,6 +24,7 @@ import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.KAppContainer;
 import io.github.darthakiranihil.konna.core.di.KEngineModule;
 import io.github.darthakiranihil.konna.core.io.KAssetLoader;
+import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
 import io.github.darthakiranihil.konna.core.io.except.KAssetLoadingException;
 import io.github.darthakiranihil.konna.core.message.KEvent;
@@ -35,9 +36,6 @@ import io.github.darthakiranihil.konna.core.util.KReflectionUtils;
 import io.github.darthakiranihil.konna.level.asset.KLevelMetadataCollection;
 import io.github.darthakiranihil.konna.level.asset.KTileCollection;
 import io.github.darthakiranihil.konna.level.asset.KTilePropertyCollection;
-import io.github.darthakiranihil.konna.level.type.KLevelMetadataTypedef;
-import io.github.darthakiranihil.konna.level.type.KTilePropertyTypedef;
-import io.github.darthakiranihil.konna.level.type.KTileTypedef;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -74,12 +72,11 @@ public class KStandardLevelLoaderNegativeTests extends KStandardTestClass {
         this.assetLoader = new KJsonAssetLoader(
             engineModule.resourceLoader(),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][]{
+                KLevelComponent.getAssetTypedefs2()
+            }
         );
-
-        this.assetLoader.addAssetTypedef(new KTilePropertyTypedef());
-        this.assetLoader.addAssetTypedef(new KTileTypedef());
-        this.assetLoader.addAssetTypedef(new KLevelMetadataTypedef());
 
         this.es = new KStandardEventSystem();
         this.es.registerEvent(new KEvent<KLevelSector.EventData>("entityMoved"));

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderNegativeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderNegativeTests.java
@@ -74,7 +74,7 @@ public class KStandardLevelLoaderNegativeTests extends KStandardTestClass {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][]{
-                KLevelComponent.getAssetTypedefs2()
+                KLevelComponent.getAssetTypedefs()
             }
         );
 

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderPositiveTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderPositiveTests.java
@@ -24,6 +24,7 @@ import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.KAppContainer;
 import io.github.darthakiranihil.konna.core.di.KEngineModule;
 import io.github.darthakiranihil.konna.core.io.KAssetLoader;
+import io.github.darthakiranihil.konna.core.io.KAssetTypedef;
 import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
 import io.github.darthakiranihil.konna.core.message.KEvent;
 import io.github.darthakiranihil.konna.core.message.KEventSystem;
@@ -42,9 +43,6 @@ import io.github.darthakiranihil.konna.level.impl.TestController;
 import io.github.darthakiranihil.konna.level.impl.TestControllerWithoutValidator;
 import io.github.darthakiranihil.konna.level.layer.KTransitionedLevelType;
 import io.github.darthakiranihil.konna.level.layer.tool.KLevelTransitionLayerTool;
-import io.github.darthakiranihil.konna.level.type.KLevelMetadataTypedef;
-import io.github.darthakiranihil.konna.level.type.KTilePropertyTypedef;
-import io.github.darthakiranihil.konna.level.type.KTileTypedef;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -80,12 +78,11 @@ public class KStandardLevelLoaderPositiveTests extends KStandardTestClass {
         KAssetLoader assetLoader = new KJsonAssetLoader(
             engineModule.resourceLoader(),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] { "classpath:assets/" }
+            new String[] { "classpath:assets/" },
+            new KAssetTypedef[][]{
+                KLevelComponent.getAssetTypedefs2()
+            }
         );
-
-        assetLoader.addAssetTypedef(new KTilePropertyTypedef());
-        assetLoader.addAssetTypedef(new KTileTypedef());
-        assetLoader.addAssetTypedef(new KLevelMetadataTypedef());
 
         this.levelCollection = new KLevelMetadataCollection(assetLoader);
         this.levelLoader = new KStandardLevelLoader(

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderPositiveTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderPositiveTests.java
@@ -80,7 +80,7 @@ public class KStandardLevelLoaderPositiveTests extends KStandardTestClass {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] { "classpath:assets/" },
             new KAssetTypedef[][]{
-                KLevelComponent.getAssetTypedefs2()
+                KLevelComponent.getAssetTypedefs()
             }
         );
 

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/modules/ContextModule.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/modules/ContextModule.java
@@ -20,10 +20,7 @@ import io.github.darthakiranihil.konna.core.app.*;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonParser;
 import io.github.darthakiranihil.konna.core.data.json.KStandardJsonTokenizer;
 import io.github.darthakiranihil.konna.core.di.*;
-import io.github.darthakiranihil.konna.core.io.KAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KJsonAssetLoader;
-import io.github.darthakiranihil.konna.core.io.KResourceLoader;
-import io.github.darthakiranihil.konna.core.io.KStandardResourceLoader;
+import io.github.darthakiranihil.konna.core.io.*;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
 import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KMessageSystem;
@@ -33,6 +30,7 @@ import io.github.darthakiranihil.konna.core.object.KActivator;
 import io.github.darthakiranihil.konna.core.object.KObjectRegistry;
 import io.github.darthakiranihil.konna.core.object.KStandardActivator;
 import io.github.darthakiranihil.konna.core.object.KStandardObjectRegistry;
+import io.github.darthakiranihil.konna.level.KLevelComponent;
 
 import java.util.List;
 
@@ -84,7 +82,10 @@ public class ContextModule extends KAbstractModule {
         return new KJsonAssetLoader(
             this.appContainer.getInstanceInferred(KResourceLoader.class),
             new KStandardJsonParser(new KStandardJsonTokenizer()),
-            new String[] {  "/dev/null" }
+            new String[] {  "/dev/null" },
+            new KAssetTypedef[][]{
+                KLevelComponent.getAssetTypedefs2()
+            }
         );
     }
 

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/modules/ContextModule.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/modules/ContextModule.java
@@ -84,7 +84,7 @@ public class ContextModule extends KAbstractModule {
             new KStandardJsonParser(new KStandardJsonTokenizer()),
             new String[] {  "/dev/null" },
             new KAssetTypedef[][]{
-                KLevelComponent.getAssetTypedefs2()
+                KLevelComponent.getAssetTypedefs()
             }
         );
     }


### PR DESCRIPTION
1. feat: add forward asset typedef passing to asset loader instead of doing this on hypervivsor loading
2. feat: remove getAssetTypedefs from KComponent and replace it with a static analogue