### PR TITLE
[#287] Feat: Replace vector constructors with factory methods that look for previously instantiated vectors with same parameters

### DIFF
--- a/backend/backend-spair/src/main/java/io/github/darthakiranihil/konna/backend/spair/imgui/KImGuiSpairUnwrapper.java
+++ b/backend/backend-spair/src/main/java/io/github/darthakiranihil/konna/backend/spair/imgui/KImGuiSpairUnwrapper.java
@@ -33,7 +33,7 @@ final class KImGuiSpairUnwrapper extends KUninstantiable {
     }
 
     public static KVector2f wrap(final ImVec2 original) {
-        return new KVector2f(original.x, original.y);
+        return KVectors.new2f(original.x, original.y);
     }
 
     public static KVector4f wrap(final ImVec4 original) {

--- a/backend/backend-spair/src/main/java/io/github/darthakiranihil/konna/backend/spair/imgui/KImGuiSpairUnwrapper.java
+++ b/backend/backend-spair/src/main/java/io/github/darthakiranihil/konna/backend/spair/imgui/KImGuiSpairUnwrapper.java
@@ -21,6 +21,7 @@ import imgui.internal.ImGuiContext;
 import io.github.darthakiranihil.konna.core.object.KUninstantiable;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector4f;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KExcludeFromGeneratedCoverageReport;
 import io.github.darthakiranihil.konna.libfrontend.imgui.*;
 
@@ -36,7 +37,7 @@ final class KImGuiSpairUnwrapper extends KUninstantiable {
     }
 
     public static KVector4f wrap(final ImVec4 original) {
-        return new KVector4f(original.x, original.y, original.z, original.w);
+        return KVectors.new4f(original.x, original.y, original.z, original.w);
     }
 
     public static KImGuiContext wrap(final ImGuiContext original) {

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponentLoader.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponentLoader.java
@@ -29,8 +29,8 @@ import io.github.darthakiranihil.konna.core.engine.except.KComponentLoadingExcep
 import io.github.darthakiranihil.konna.core.io.KResource;
 import io.github.darthakiranihil.konna.core.io.KResourceLoader;
 import io.github.darthakiranihil.konna.core.object.KActivator;
-import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.service.KRenderService;
 
 import java.io.InputStream;
@@ -101,7 +101,7 @@ public class KGraphicsComponentLoader implements KComponentLoader {
             new KTransform(
                 0.0,
                 new KVector2i(1, 1),
-                new KVector2f(0.0f, 0.0f),
+                KVectors.new2f(0.0f, 0.0f),
                 KVector2i.ZERO
             )
         ).getMatrix();

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponentLoader.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KGraphicsComponentLoader.java
@@ -100,7 +100,7 @@ public class KGraphicsComponentLoader implements KComponentLoader {
         (
             new KTransform(
                 0.0,
-                new KVector2i(1, 1),
+                KVectors.new2i(1, 1),
                 KVectors.new2f(0.0f, 0.0f),
                 KVector2i.ZERO
             )

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KTransform.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/KTransform.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.graphics;
 import io.github.darthakiranihil.konna.core.except.KIllegalStateException;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
@@ -124,7 +125,7 @@ public final class KTransform {
      * @return This object (for method chaining)
      */
     public KTransform scale(final KVector2f factor) {
-        this.scaling = new KVector2f(this.scaling.x() * factor.x(), this.scaling.y() * factor.y());
+        this.scaling = KVectors.new2f(this.scaling.x() * factor.x(), this.scaling.y() * factor.y());
         this.invalidateCache();
         return this;
     }

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/asset/KTextureSliceSetCollection.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/asset/KTextureSliceSetCollection.java
@@ -27,6 +27,7 @@ import io.github.darthakiranihil.konna.core.object.KDefaultTags;
 import io.github.darthakiranihil.konna.core.object.KObject;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.image.KTexture;
 import io.github.darthakiranihil.konna.graphics.image.KTextureSliceData;
@@ -109,7 +110,7 @@ public final class KTextureSliceSetCollection
 
             for (int i = 0; i < componentsCount; i++) {
 
-                uv[i] = new KVector2f(
+                uv[i] = KVectors.new2f(
                     rawUv[i].getFloat("u"),
                     rawUv[i].getFloat("v")
                 );

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/asset/KTextureSliceSetCollection.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/asset/KTextureSliceSetCollection.java
@@ -115,7 +115,7 @@ public final class KTextureSliceSetCollection
                     rawUv[i].getFloat("v")
                 );
 
-                xy[i] = new KVector2i(
+                xy[i] = KVectors.new2i(
                     rawXy[i].getInt("x"),
                     rawXy[i].getInt("y")
                 );

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/image/KRenderableTexture.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/image/KRenderableTexture.java
@@ -19,10 +19,10 @@ package io.github.darthakiranihil.konna.graphics.image;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
 import io.github.darthakiranihil.konna.core.struct.KVectors;
-import io.github.darthakiranihil.konna.test.KExcludeFromGeneratedCoverageReport;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.render.KRenderFrontend;
 import io.github.darthakiranihil.konna.graphics.shape.KAbstractShape;
+import io.github.darthakiranihil.konna.test.KExcludeFromGeneratedCoverageReport;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -103,19 +103,19 @@ public class KRenderableTexture extends KAbstractShape {
 
         KImage sourceImage = texture.attachedImage();
         KVector2i[] xy = new KVector2i[] {
-            new KVector2i(
+            KVectors.new2i(
                 leftTopCorner.x(),
                 leftTopCorner.y()
             ),
-            new KVector2i(
+            KVectors.new2i(
                 leftTopCorner.x() + sourceImage.width(),
                 leftTopCorner.y()
             ),
-            new KVector2i(
+            KVectors.new2i(
                 leftTopCorner.x() + sourceImage.width(),
                 leftTopCorner.y() + sourceImage.height()
             ),
-            new KVector2i(
+            KVectors.new2i(
                 leftTopCorner.x(),
                 leftTopCorner.y() + sourceImage.height()
             ),

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/image/KRenderableTexture.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/image/KRenderableTexture.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.graphics.image;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KExcludeFromGeneratedCoverageReport;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.render.KRenderFrontend;
@@ -36,10 +37,10 @@ import java.util.Objects;
 public class KRenderableTexture extends KAbstractShape {
 
     private static final KVector2f[] DEFAULT_UV = new KVector2f[] {
-        new KVector2f(0.0f, 0.0f),
-        new KVector2f(1.0f, 0.0f),
-        new KVector2f(1.0f, 1.0f),
-        new KVector2f(0.0f, 1.0f),
+        KVectors.new2f(0.0f, 0.0f),
+        KVectors.new2f(1.0f, 0.0f),
+        KVectors.new2f(1.0f, 1.0f),
+        KVectors.new2f(0.0f, 1.0f),
     };
 
     private static final KColor[] ALL_WHITES = new KColor[] {

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KAbstractShape.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KAbstractShape.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KExcludeFromGeneratedCoverageReport;
 import io.github.darthakiranihil.konna.graphics.KTransform;
 import io.github.darthakiranihil.konna.graphics.shader.KShaderProgram;
@@ -97,7 +98,7 @@ public abstract class KAbstractShape implements KShape {
         x /= 6 * signedArea;
         y /= 6 * signedArea;
 
-        return new KVector2i((int) x, (int) y);
+        return KVectors.new2i((int) x, (int) y);
     }
 
 }

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KArc.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KArc.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.render.KRenderFrontend;
 import io.github.darthakiranihil.konna.graphics.shader.KShaderProgram;
@@ -107,7 +108,7 @@ public class KArc extends KAbstractShape {
      */
     public KArc(int x, int y, int width, int height, int startAngle, int arcAngle) {
         this(
-            new KVector2i(x, y),
+            KVectors.new2i(x, y),
             new KSize(width, height),
             startAngle,
             arcAngle,
@@ -137,7 +138,7 @@ public class KArc extends KAbstractShape {
         final KColor outlineColor
     ) {
         this(
-            new KVector2i(x, y),
+            KVectors.new2i(x, y),
             new KSize(width, height),
             startAngle,
             arcAngle,
@@ -168,7 +169,7 @@ public class KArc extends KAbstractShape {
         final KColor fillColor
     ) {
         this(
-            new KVector2i(x, y),
+            KVectors.new2i(x, y),
             new KSize(width, height),
             startAngle,
             arcAngle,
@@ -273,7 +274,7 @@ public class KArc extends KAbstractShape {
         final KShaderProgram shader
     ) {
         this(
-            new KVector2i(x, y),
+            KVectors.new2i(x, y),
             new KSize(width, height),
             startAngle,
             arcAngle,
@@ -307,7 +308,7 @@ public class KArc extends KAbstractShape {
         final KColor outlineColor
     ) {
         this(
-            new KVector2i(x, y),
+            KVectors.new2i(x, y),
             new KSize(width, height),
             startAngle,
             arcAngle,
@@ -342,7 +343,7 @@ public class KArc extends KAbstractShape {
         final KColor fillColor
     ) {
         this(
-            new KVector2i(x, y),
+            KVectors.new2i(x, y),
             new KSize(width, height),
             startAngle,
             arcAngle,

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KLine.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KLine.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.render.KRenderFrontend;
 import io.github.darthakiranihil.konna.graphics.shader.KShaderProgram;
@@ -42,7 +43,7 @@ public class KLine extends KAbstractShape {
      * @param color Line's color
      */
     public KLine(final KVector2i start, final KVector2i end, final KColor color) {
-        super(new KVector2i(
+        super(KVectors.new2i(
             start.x() / 2,
             start.y() / 2
         ));
@@ -70,7 +71,7 @@ public class KLine extends KAbstractShape {
      * @param color Line's color
      */
     public KLine(int x1, int x2, int y1, int y2, final KColor color) {
-        this(new KVector2i(x1, y1), new KVector2i(x2, y2), color);
+        this(KVectors.new2i(x1, y1), KVectors.new2i(x2, y2), color);
     }
 
     /**
@@ -82,7 +83,7 @@ public class KLine extends KAbstractShape {
      * @param y2 Y coordinate of end of the line
      */
     public KLine(int x1, int x2, int y1, int y2) {
-        this(new KVector2i(x1, y1), new KVector2i(x2, y2), KColor.TRANSPARENT);
+        this(KVectors.new2i(x1, y1), KVectors.new2i(x2, y2), KColor.TRANSPARENT);
     }
 
     /**
@@ -99,7 +100,7 @@ public class KLine extends KAbstractShape {
         final KColor color
     ) {
         super(
-            new KVector2i(
+            KVectors.new2i(
                 start.x() / 2,
                 start.y() / 2
             ),
@@ -142,7 +143,7 @@ public class KLine extends KAbstractShape {
         final KShaderProgram shader,
         final KColor color
     ) {
-        this(new KVector2i(x1, y1), new KVector2i(x2, y2), shader, color);
+        this(KVectors.new2i(x1, y1), KVectors.new2i(x2, y2), shader, color);
     }
 
     /**
@@ -156,7 +157,7 @@ public class KLine extends KAbstractShape {
      * @param shader Specific shader used for its rendering
      */
     public KLine(int x1, int x2, int y1, int y2, final KShaderProgram shader) {
-        this(new KVector2i(x1, y1), new KVector2i(x2, y2), shader, KColor.TRANSPARENT);
+        this(KVectors.new2i(x1, y1), KVectors.new2i(x2, y2), shader, KColor.TRANSPARENT);
     }
 
     @Override

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KOval.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KOval.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.render.KRenderFrontend;
 import io.github.darthakiranihil.konna.graphics.shader.KShaderProgram;
@@ -119,7 +120,7 @@ public class KOval extends KAbstractShape {
         final KColor outlineColor,
         final KColor fillColor
     ) {
-        this(new KVector2i(x, y), new KSize(width, height), outlineColor, fillColor);
+        this(KVectors.new2i(x, y), new KSize(width, height), outlineColor, fillColor);
     }
 
     /**
@@ -226,7 +227,7 @@ public class KOval extends KAbstractShape {
         final KColor outlineColor,
         final KColor fillColor
     ) {
-        this(new KVector2i(x, y), new KSize(width, height), shader, outlineColor, fillColor);
+        this(KVectors.new2i(x, y), new KSize(width, height), shader, outlineColor, fillColor);
     }
 
     /**

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KRectangle.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/shape/KRectangle.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.render.KRenderFrontend;
 import io.github.darthakiranihil.konna.graphics.shader.KShaderProgram;
@@ -95,10 +96,10 @@ public class KRectangle extends KPolygon {
     ) {
         super(
             new KVector2i[] {
-                new KVector2i(x, y),
-                new KVector2i(x + width, y),
-                new KVector2i(x + width, y + height),
-                new KVector2i(x, y + height),
+                KVectors.new2i(x, y),
+                KVectors.new2i(x + width, y),
+                KVectors.new2i(x + width, y + height),
+                KVectors.new2i(x, y + height),
             },
             outlineColor,
             fillColor
@@ -207,10 +208,10 @@ public class KRectangle extends KPolygon {
     ) {
         super(
             new KVector2i[] {
-                new KVector2i(x, y),
-                new KVector2i(x + width, y),
-                new KVector2i(x + width, y + height),
-                new KVector2i(x, y + height),
+                KVectors.new2i(x, y),
+                KVectors.new2i(x + width, y),
+                KVectors.new2i(x + width, y + height),
+                KVectors.new2i(x, y + height),
             },
             shader,
             outlineColor,

--- a/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/text/KTiledText.java
+++ b/components/component-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/text/KTiledText.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.graphics.text;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.core.util.KStringUtils;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.image.KRenderableTexture;
@@ -241,28 +242,28 @@ public class KTiledText extends KAbstractShape {
             }
 
             KVector2f[] glyphUv = glyphs[i].uv();
-            xy[putChars * ELEMENTS_PER_GLYPH] = new KVector2i(
+            xy[putChars * ELEMENTS_PER_GLYPH] = KVectors.new2i(
                 this.startPos.x() + column * this.font.glyphSize().width(),
                 this.startPos.y() + line * this.font.glyphSize().height()
             );
             uv[putChars * ELEMENTS_PER_GLYPH] = glyphUv[0];
             colors[putChars * ELEMENTS_PER_GLYPH] = this.color;
 
-            xy[putChars * ELEMENTS_PER_GLYPH + 1] = new KVector2i(
+            xy[putChars * ELEMENTS_PER_GLYPH + 1] = KVectors.new2i(
                 this.startPos.x() + (column + 1) * this.font.glyphSize().width(),
                 this.startPos.y() + line * this.font.glyphSize().height()
             );
             uv[putChars * ELEMENTS_PER_GLYPH + 1] = glyphUv[1];
             colors[putChars * ELEMENTS_PER_GLYPH + 1] = this.color;
 
-            xy[putChars * ELEMENTS_PER_GLYPH + 2] = new KVector2i(
+            xy[putChars * ELEMENTS_PER_GLYPH + 2] = KVectors.new2i(
                 this.startPos.x() + (column + 1) * this.font.glyphSize().width(),
                 this.startPos.y() + (line + 1) * this.font.glyphSize().height()
             );
             uv[putChars * ELEMENTS_PER_GLYPH + 2] = glyphUv[2];
             colors[putChars * ELEMENTS_PER_GLYPH + 2] = this.color;
 
-            xy[putChars * ELEMENTS_PER_GLYPH + 3] = new KVector2i(
+            xy[putChars * ELEMENTS_PER_GLYPH + 3] = KVectors.new2i(
                 this.startPos.x() + column * this.font.glyphSize().width(),
                 this.startPos.y() + (line + 1) * this.font.glyphSize().height()
             );

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KRenderableTextureCollectionPositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KRenderableTextureCollectionPositiveTests.java
@@ -66,10 +66,10 @@ public class KRenderableTextureCollectionPositiveTests extends KAssetCollectionT
 
         Assertions.assertArrayEquals(
             new KVector2i[] {
-                new KVector2i(0, 0),
-                new KVector2i(16, 0),
-                new KVector2i(16, 16),
-                new KVector2i(0, 16)
+                KVectors.new2i(0, 0),
+                KVectors.new2i(16, 0),
+                KVectors.new2i(16, 16),
+                KVectors.new2i(0, 16)
             },
             tex.xy()
         );
@@ -126,14 +126,14 @@ public class KRenderableTextureCollectionPositiveTests extends KAssetCollectionT
             textureSliceSetCollection
         );
 
-        KRenderableTexture tex = collection.getAsset("sl1", new KVector2i(400, 400));
+        KRenderableTexture tex = collection.getAsset("sl1", KVectors.new2i(400, 400));
 
         Assertions.assertArrayEquals(
             new KVector2i[] {
-                new KVector2i(400, 400),
-                new KVector2i(416, 400),
-                new KVector2i(416, 416),
-                new KVector2i(400, 416)
+                KVectors.new2i(400, 400),
+                KVectors.new2i(416, 400),
+                KVectors.new2i(416, 416),
+                KVectors.new2i(400, 416)
             },
             tex.xy()
         );
@@ -194,10 +194,10 @@ public class KRenderableTextureCollectionPositiveTests extends KAssetCollectionT
 
         Assertions.assertArrayEquals(
             new KVector2i[] {
-                new KVector2i(0, 0),
-                new KVector2i(400, 0),
-                new KVector2i(400, 507),
-                new KVector2i(0, 507)
+                KVectors.new2i(0, 0),
+                KVectors.new2i(400, 0),
+                KVectors.new2i(400, 507),
+                KVectors.new2i(0, 507)
             },
             tex.xy()
         );
@@ -254,14 +254,14 @@ public class KRenderableTextureCollectionPositiveTests extends KAssetCollectionT
             textureSliceSetCollection
         );
 
-        KRenderableTexture tex = collection.getAsset("slt2", new KVector2i(400, 400));
+        KRenderableTexture tex = collection.getAsset("slt2", KVectors.new2i(400, 400));
 
         Assertions.assertArrayEquals(
             new KVector2i[] {
-                new KVector2i(400, 400),
-                new KVector2i(800, 400),
-                new KVector2i(800, 907),
-                new KVector2i(400, 907)
+                KVectors.new2i(400, 400),
+                KVectors.new2i(800, 400),
+                KVectors.new2i(800, 907),
+                KVectors.new2i(400, 907)
             },
             tex.xy()
         );

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KRenderableTextureCollectionPositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KRenderableTextureCollectionPositiveTests.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.graphics.asset;
 import io.github.darthakiranihil.konna.backend.lwjgl.stbimage.KStbImageLwjgl;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.image.KRenderableTexture;
 import io.github.darthakiranihil.konna.graphics.impl.TestShaderCompiler;
@@ -74,10 +75,10 @@ public class KRenderableTextureCollectionPositiveTests extends KAssetCollectionT
         );
         Assertions.assertArrayEquals(
             new KVector2f[] {
-                new KVector2f(0.0f, 0.0f),
-                new KVector2f(1.0f, 0.0f),
-                new KVector2f(0.5f, 0.5f),
-                new KVector2f(0.0f, 0.5f)
+                KVectors.new2f(0.0f, 0.0f),
+                KVectors.new2f(1.0f, 0.0f),
+                KVectors.new2f(0.5f, 0.5f),
+                KVectors.new2f(0.0f, 0.5f)
             },
             tex.uv()
         );
@@ -138,10 +139,10 @@ public class KRenderableTextureCollectionPositiveTests extends KAssetCollectionT
         );
         Assertions.assertArrayEquals(
             new KVector2f[] {
-                new KVector2f(0.0f, 0.0f),
-                new KVector2f(1.0f, 0.0f),
-                new KVector2f(0.5f, 0.5f),
-                new KVector2f(0.0f, 0.5f)
+                KVectors.new2f(0.0f, 0.0f),
+                KVectors.new2f(1.0f, 0.0f),
+                KVectors.new2f(0.5f, 0.5f),
+                KVectors.new2f(0.0f, 0.5f)
             },
             tex.uv()
         );
@@ -202,10 +203,10 @@ public class KRenderableTextureCollectionPositiveTests extends KAssetCollectionT
         );
         Assertions.assertArrayEquals(
             new KVector2f[] {
-                new KVector2f(0.0f, 0.0f),
-                new KVector2f(1.0f, 0.0f),
-                new KVector2f(1.0f, 1.0f),
-                new KVector2f(0.0f, 1.0f)
+                KVectors.new2f(0.0f, 0.0f),
+                KVectors.new2f(1.0f, 0.0f),
+                KVectors.new2f(1.0f, 1.0f),
+                KVectors.new2f(0.0f, 1.0f)
             },
             tex.uv()
         );
@@ -266,10 +267,10 @@ public class KRenderableTextureCollectionPositiveTests extends KAssetCollectionT
         );
         Assertions.assertArrayEquals(
             new KVector2f[] {
-                new KVector2f(0.0f, 0.0f),
-                new KVector2f(1.0f, 0.0f),
-                new KVector2f(1.0f, 1.0f),
-                new KVector2f(0.0f, 1.0f)
+                KVectors.new2f(0.0f, 0.0f),
+                KVectors.new2f(1.0f, 0.0f),
+                KVectors.new2f(1.0f, 1.0f),
+                KVectors.new2f(0.0f, 1.0f)
             },
             tex.uv()
         );

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KTextureSliceSetCollectionPositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KTextureSliceSetCollectionPositiveTests.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.graphics.asset;
 import io.github.darthakiranihil.konna.backend.lwjgl.stbimage.KStbImageLwjgl;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.image.KRenderableTexture;
 import io.github.darthakiranihil.konna.graphics.image.KTextureSliceSet;
@@ -79,10 +80,10 @@ public class KTextureSliceSetCollectionPositiveTests extends KAssetCollectionTes
 
         Assertions.assertArrayEquals(
             new KVector2f[] {
-                new KVector2f(0.0f, 0.0f),
-                new KVector2f(1.0f, 0.0f),
-                new KVector2f(0.5f, 0.5f),
-                new KVector2f(0.0f, 0.5f)
+                KVectors.new2f(0.0f, 0.0f),
+                KVectors.new2f(1.0f, 0.0f),
+                KVectors.new2f(0.5f, 0.5f),
+                KVectors.new2f(0.0f, 0.5f)
             },
             uv
         );
@@ -148,10 +149,10 @@ public class KTextureSliceSetCollectionPositiveTests extends KAssetCollectionTes
 
         Assertions.assertArrayEquals(
             new KVector2f[] {
-                new KVector2f(0.0f, 0.0f),
-                new KVector2f(1.0f, 0.0f),
-                new KVector2f(0.5f, 0.5f),
-                new KVector2f(0.0f, 0.5f)
+                KVectors.new2f(0.0f, 0.0f),
+                KVectors.new2f(1.0f, 0.0f),
+                KVectors.new2f(0.5f, 0.5f),
+                KVectors.new2f(0.0f, 0.5f)
             },
             uv
         );

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KTextureSliceSetCollectionPositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/asset/KTextureSliceSetCollectionPositiveTests.java
@@ -70,10 +70,10 @@ public class KTextureSliceSetCollectionPositiveTests extends KAssetCollectionTes
 
         Assertions.assertArrayEquals(
             new KVector2i[] {
-                new KVector2i(0, 0),
-                new KVector2i(16, 0),
-                new KVector2i(16, 16),
-                new KVector2i(0, 16)
+                KVectors.new2i(0, 0),
+                KVectors.new2i(16, 0),
+                KVectors.new2i(16, 16),
+                KVectors.new2i(0, 16)
             },
             xy
         );
@@ -126,7 +126,7 @@ public class KTextureSliceSetCollectionPositiveTests extends KAssetCollectionTes
         KTextureSliceSet set = collection.getAsset("set_1");
         collection.getAsset("set_1");
 
-        KRenderableTexture tex = set.getTexture("sl1", new KVector2i(400, 400), 1);
+        KRenderableTexture tex = set.getTexture("sl1", KVectors.new2i(400, 400), 1);
         Assertions.assertEquals(1, tex.getUnit());
 
         KVector2i[] xy = tex.xy();
@@ -139,10 +139,10 @@ public class KTextureSliceSetCollectionPositiveTests extends KAssetCollectionTes
 
         Assertions.assertArrayEquals(
             new KVector2i[] {
-                new KVector2i(400, 400),
-                new KVector2i(416, 400),
-                new KVector2i(416, 416),
-                new KVector2i(400, 416)
+                KVectors.new2i(400, 400),
+                KVectors.new2i(416, 400),
+                KVectors.new2i(416, 416),
+                KVectors.new2i(400, 416)
             },
             xy
         );

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/image/KRenderableTexturePositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/image/KRenderableTexturePositiveTests.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.graphics.image;
 import io.github.darthakiranihil.konna.backend.lwjgl.stbimage.KStbImageLwjgl;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.asset.KAssetCollectionTestClass;
@@ -76,10 +77,10 @@ public class KRenderableTexturePositiveTests extends KAssetCollectionTestClass {
         };
 
         KVector2f[] uvs = new KVector2f[] {
-            new KVector2f(0.0f, 0.0f),
-            new KVector2f(1.0f, 0.0f),
-            new KVector2f(1.0f, 1.0f),
-            new KVector2f(0.0f, 1.0f),
+            KVectors.new2f(0.0f, 0.0f),
+            KVectors.new2f(1.0f, 0.0f),
+            KVectors.new2f(1.0f, 1.0f),
+            KVectors.new2f(0.0f, 1.0f),
         };
 
         KVector2i[] xy = rtex.xy();

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/image/KRenderableTexturePositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/image/KRenderableTexturePositiveTests.java
@@ -56,7 +56,7 @@ public class KRenderableTexturePositiveTests extends KAssetCollectionTestClass {
 
         KRenderableTexture rtex = KRenderableTexture.wrapIntoRectangle(
             "tt",
-            new KVector2i(10, 10),
+            KVectors.new2i(10, 10),
             tex,
             0
         );
@@ -70,10 +70,10 @@ public class KRenderableTexturePositiveTests extends KAssetCollectionTestClass {
         };
 
         KVector2i[] points = new KVector2i[] {
-            new KVector2i(10, 10),
-            new KVector2i(410, 10),
-            new KVector2i(410, 517),
-            new KVector2i(10, 517),
+            KVectors.new2i(10, 10),
+            KVectors.new2i(410, 10),
+            KVectors.new2i(410, 517),
+            KVectors.new2i(10, 517),
         };
 
         KVector2f[] uvs = new KVector2f[] {

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KArcPositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KArcPositiveTests.java
@@ -18,13 +18,14 @@ package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class KArcPositiveTests extends KShapeTestClass {
 
-    private final KVector2i coordinates = new KVector2i(10, 10);
+    private final KVector2i coordinates = KVectors.new2i(10, 10);
     private final KSize size = new KSize(10, 10);
     private final int startAngle = 30;
     private final int arcAngle = 60;

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KCirclePositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KCirclePositiveTests.java
@@ -17,12 +17,13 @@
 package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import org.junit.jupiter.api.Test;
 
 public class KCirclePositiveTests extends KShapeTestClass {
 
-    private final KVector2i coordinates = new KVector2i(10, 10);
+    private final KVector2i coordinates = KVectors.new2i(10, 10);
     private final int radius = 1;
     private final KColor outlineColor = KColor.DARK_GRAY;
     private final KColor fillColor = KColor.LIGHT_GRAY;

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KLinePositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KLinePositiveTests.java
@@ -17,14 +17,15 @@
 package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class KLinePositiveTests extends KShapeTestClass {
 
-    private final KVector2i start = new KVector2i(10, 10);
-    private final KVector2i end = new KVector2i(16, 16);
+    private final KVector2i start = KVectors.new2i(10, 10);
+    private final KVector2i end = KVectors.new2i(16, 16);
     private final KColor color = KColor.WHITE;
 
     @Test

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KOvalPositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KOvalPositiveTests.java
@@ -18,13 +18,14 @@ package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class KOvalPositiveTests extends KShapeTestClass {
 
-    private final KVector2i center = new KVector2i(10, 10);
+    private final KVector2i center = KVectors.new2i(10, 10);
     private final KSize size = new KSize(10, 10);
     private final KColor outlineColor = KColor.RED;
     private final KColor fillColor = KColor.BLUE;

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KPolygonPositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KPolygonPositiveTests.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,9 +25,9 @@ import org.junit.jupiter.api.Test;
 public class KPolygonPositiveTests extends KShapeTestClass {
 
     private final KVector2i[] points = new KVector2i[] {
-        new KVector2i(10, 10),
-        new KVector2i(10, 16),
-        new KVector2i(16, 16),
+        KVectors.new2i(10, 10),
+        KVectors.new2i(10, 16),
+        KVectors.new2i(16, 16),
     };
     private final int[] xs = new int[] {10, 10, 16};
     private final int[] ys = new int[] {10, 16, 16};
@@ -136,9 +137,9 @@ public class KPolygonPositiveTests extends KShapeTestClass {
 
         KPolygon primal = new KPolygon(
             new KVector2i[] {
-                new KVector2i(10, 10),
-                new KVector2i(10, 16),
-                new KVector2i(16, 16),
+                KVectors.new2i(10, 10),
+                KVectors.new2i(10, 16),
+                KVectors.new2i(16, 16),
             },
             KColor.PINK,
             KColor.BLUE
@@ -146,27 +147,27 @@ public class KPolygonPositiveTests extends KShapeTestClass {
 
         KPolygon diff1 = new KPolygon(
             new KVector2i[] {
-                new KVector2i(10, 11),
-                new KVector2i(10, 16),
-                new KVector2i(16, 16),
+                KVectors.new2i(10, 11),
+                KVectors.new2i(10, 16),
+                KVectors.new2i(16, 16),
             },
             KColor.PINK,
             KColor.BLUE
         );
         KPolygon diff2 = new KPolygon(
             new KVector2i[] {
-                new KVector2i(10, 10),
-                new KVector2i(10, 16),
-                new KVector2i(16, 16),
+                KVectors.new2i(10, 10),
+                KVectors.new2i(10, 16),
+                KVectors.new2i(16, 16),
             },
             KColor.GREEN,
             KColor.BLUE
         );
         KPolygon diff3 = new KPolygon(
             new KVector2i[] {
-                new KVector2i(10, 10),
-                new KVector2i(10, 16),
-                new KVector2i(16, 16),
+                KVectors.new2i(10, 10),
+                KVectors.new2i(10, 16),
+                KVectors.new2i(16, 16),
             },
             KColor.PINK,
             KColor.RED
@@ -174,9 +175,9 @@ public class KPolygonPositiveTests extends KShapeTestClass {
 
         KPolygon equal = new KPolygon(
             new KVector2i[] {
-                new KVector2i(10, 10),
-                new KVector2i(10, 16),
-                new KVector2i(16, 16),
+                KVectors.new2i(10, 10),
+                KVectors.new2i(10, 16),
+                KVectors.new2i(16, 16),
             },
             KColor.PINK,
             KColor.BLUE

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KPolylinePositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KPolylinePositiveTests.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,9 +25,9 @@ import org.junit.jupiter.api.Test;
 public class KPolylinePositiveTests extends KShapeTestClass {
 
     private final KVector2i[] points = new KVector2i[] {
-        new KVector2i(10, 10),
-        new KVector2i(10, 16),
-        new KVector2i(16, 16),
+        KVectors.new2i(10, 10),
+        KVectors.new2i(10, 16),
+        KVectors.new2i(16, 16),
     };
     private final int[] xs = new int[] {10, 10, 16};
     private final int[] ys = new int[] {10, 16, 16};
@@ -103,35 +104,35 @@ public class KPolylinePositiveTests extends KShapeTestClass {
 
         KPolyline primal = new KPolyline(
             new KVector2i[] {
-                new KVector2i(10, 10),
-                new KVector2i(10, 16),
-                new KVector2i(16, 16),
+                KVectors.new2i(10, 10),
+                KVectors.new2i(10, 16),
+                KVectors.new2i(16, 16),
             },
             KColor.PINK
         );
 
         KPolyline diff1 = new KPolyline(
             new KVector2i[] {
-                new KVector2i(10, 11),
-                new KVector2i(10, 16),
-                new KVector2i(16, 16),
+                KVectors.new2i(10, 11),
+                KVectors.new2i(10, 16),
+                KVectors.new2i(16, 16),
             },
             KColor.PINK
         );
         KPolyline diff2 = new KPolyline(
             new KVector2i[] {
-                new KVector2i(10, 10),
-                new KVector2i(10, 16),
-                new KVector2i(16, 16),
+                KVectors.new2i(10, 10),
+                KVectors.new2i(10, 16),
+                KVectors.new2i(16, 16),
             },
             KColor.GREEN
         );
 
         KPolyline equal = new KPolyline(
             new KVector2i[] {
-                new KVector2i(10, 10),
-                new KVector2i(10, 16),
-                new KVector2i(16, 16),
+                KVectors.new2i(10, 10),
+                KVectors.new2i(10, 16),
+                KVectors.new2i(16, 16),
             },
             KColor.PINK
         );

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KRectanglePositiveTests.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KRectanglePositiveTests.java
@@ -18,12 +18,13 @@ package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import org.junit.jupiter.api.Test;
 
 public class KRectanglePositiveTests extends KShapeTestClass {
 
-    private final KVector2i corner = new KVector2i(10, 10);
+    private final KVector2i corner = KVectors.new2i(10, 10);
     private final KSize size = new KSize(10, 16);
 
     private final int side = 20;

--- a/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KShapeTestClass.java
+++ b/components/component-graphics/src/test/java/io/github/darthakiranihil/konna/graphics/shape/KShapeTestClass.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.graphics.shape;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.impl.TestShaderProgram;
@@ -152,9 +153,9 @@ class KShapeTestClass extends KStandardTestClass {
         Assertions.assertEquals(4, rectanglePoints.length);
 
         Assertions.assertEquals(coordinates, rectanglePoints[0]);
-        Assertions.assertEquals(coordinates.add(new KVector2i(size.width(), 0)), rectanglePoints[1]);
+        Assertions.assertEquals(coordinates.add(KVectors.new2i(size.width(), 0)), rectanglePoints[1]);
         Assertions.assertEquals(coordinates.add(size.asIntVector()), rectanglePoints[2]);
-        Assertions.assertEquals(coordinates.add(new KVector2i(0, size.height())), rectanglePoints[3]);
+        Assertions.assertEquals(coordinates.add(KVectors.new2i(0, size.height())), rectanglePoints[3]);
 
         Assertions.assertEquals(size.width(), rectangle.width());
         Assertions.assertEquals(size.height(), rectangle.height());
@@ -177,9 +178,9 @@ class KShapeTestClass extends KStandardTestClass {
         Assertions.assertEquals(4, squarePoints.length);
 
         Assertions.assertEquals(coordinates, squarePoints[0]);
-        Assertions.assertEquals(coordinates.add(new KVector2i(side, 0)), squarePoints[1]);
-        Assertions.assertEquals(coordinates.add(new KVector2i(side, side)), squarePoints[2]);
-        Assertions.assertEquals(coordinates.add(new KVector2i(0, side)), squarePoints[3]);
+        Assertions.assertEquals(coordinates.add(KVectors.new2i(side, 0)), squarePoints[1]);
+        Assertions.assertEquals(coordinates.add(KVectors.new2i(side, side)), squarePoints[2]);
+        Assertions.assertEquals(coordinates.add(KVectors.new2i(0, side)), squarePoints[3]);
 
         Assertions.assertEquals(side, square.width());
         Assertions.assertEquals(side, square.height());

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/KLevelSector.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/KLevelSector.java
@@ -24,6 +24,7 @@ import io.github.darthakiranihil.konna.core.object.KObject;
 import io.github.darthakiranihil.konna.core.struct.KPair;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.entity.KLevelEntity;
 import io.github.darthakiranihil.konna.level.layer.*;
 import io.github.darthakiranihil.konna.level.layer.tool.*;
@@ -156,7 +157,7 @@ public final class KLevelSector extends KObject {
 
         return new KLevelSectorSlice(
             this.name,
-            new KVector2i(x, y),
+            KVectors.new2i(x, y),
             this.heightLayer.getOnPosition(x, y),
             this.tileLayer.getOnPosition(x, y),
             this.visitedPlacesLayer.getOnPosition(x, y),

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/asset/KLevelMetadataCollection.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/asset/KLevelMetadataCollection.java
@@ -28,6 +28,7 @@ import io.github.darthakiranihil.konna.core.object.KDefaultTags;
 import io.github.darthakiranihil.konna.core.object.KObject;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KLevelMetadata;
 import io.github.darthakiranihil.konna.level.KLevelSectorMetadata;
 import io.github.darthakiranihil.konna.level.entity.KAutonomousEntityController;
@@ -185,7 +186,7 @@ public final class KLevelMetadataCollection
             KAssetDefinition[] rawControllables = data.getSubdefinitionArray("controllable");
             KAssetDefinition[] rawAutonomouses = data.getSubdefinitionArray("autonomous");
 
-            KVector2i position = new KVector2i(x, y);
+            KVector2i position = KVectors.new2i(x, y);
             statics.putIfAbsent(position, new ArrayList<>(rawStatics.length));
             controllables.putIfAbsent(position, new ArrayList<>(rawControllables.length));
             autonomouses.putIfAbsent(position, new ArrayList<>(rawAutonomouses.length));
@@ -275,9 +276,9 @@ public final class KLevelMetadataCollection
             }
 
             sectorLinkMetadata[link] = new KLevelSectorMetadata.SectorLinkMetadata(
-                new KVector2i(x, y),
+                KVectors.new2i(x, y),
                 linkedSector,
-                new KVector2i(destinationX, destinationY)
+                KVectors.new2i(destinationX, destinationY)
             );
             link++;
 
@@ -326,11 +327,11 @@ public final class KLevelMetadataCollection
             }
 
             levelTransitionMetadata[transition] = new KLevelSectorMetadata.LevelTransitionMetadata(
-                new KVector2i(x, y),
+                KVectors.new2i(x, y),
                 levelDescriptor,
                 levelType,
                 destinationSector,
-                new KVector2i(destinationX, destinationY)
+                KVectors.new2i(destinationX, destinationY)
             );
             transition++;
         }

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KLevelEntityLayer.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KLevelEntityLayer.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.level.layer;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KLevelSector;
 import io.github.darthakiranihil.konna.level.entity.KLevelEntity;
 import io.github.darthakiranihil.konna.level.layer.tool.KLevelEntityLayerTool;
@@ -101,7 +102,7 @@ public final class KLevelEntityLayer
         public List<KLevelEntity> getOnPosition(int x, int y) {
             // todo: mark entity to remove and return here only unmarked
             // all marked entities must be deleted after an event or something
-            return List.copyOf(this.getOnPosition(new KVector2i(x, y)));
+            return List.copyOf(this.getOnPosition(KVectors.new2i(x, y)));
         }
 
         @Override
@@ -147,7 +148,7 @@ public final class KLevelEntityLayer
 
     @Override
     public List<KLevelEntity> getOnPosition(int x, int y) {
-        return this.getOnPosition(new KVector2i(x, y));
+        return this.getOnPosition(KVectors.new2i(x, y));
     }
 
     @Override

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KLevelTransitionLayer.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KLevelTransitionLayer.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.level.layer;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.layer.tool.KLevelTransitionLayerTool;
 import org.jspecify.annotations.Nullable;
 
@@ -81,7 +82,7 @@ public final class KLevelTransitionLayer
 
     @Override
     public @Nullable KLevelTransitionData getOnPosition(int x, int y) {
-        return this.getOnPosition(new KVector2i(x, y));
+        return this.getOnPosition(KVectors.new2i(x, y));
     }
 
     @Override

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KReachabilityAreaLayer.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KReachabilityAreaLayer.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.layer;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KTileInfo;
 import io.github.darthakiranihil.konna.level.layer.tool.KReachabilityAreaLayerTool;
 import org.jspecify.annotations.Nullable;
@@ -224,7 +225,7 @@ public final class KReachabilityAreaLayer
 
                 KTileInfo tile = sourceTileLayer.getOnPosition(i, j);
                 if (tile != null && tile.isPassable() && this.areas[j][i] == 0) {
-                    return new KVector2i(i, j);
+                    return KVectors.new2i(i, j);
                 }
 
             }
@@ -245,7 +246,7 @@ public final class KReachabilityAreaLayer
 
         KTileInfo tileInfo = sourceTileLayer.getOnPosition(x, y);
         int height = sourceHeightLayer.getOnPosition(x, y);
-        KVector2i pos = new KVector2i(x, y);
+        KVector2i pos = KVectors.new2i(x, y);
         if (
                 tileInfo != null
             &&  tileInfo.isPassable()

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KSectorLinkLayer.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KSectorLinkLayer.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.level.layer;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KLevelSector;
 import io.github.darthakiranihil.konna.level.layer.tool.KSectorLinkLayerTool;
 import org.jspecify.annotations.Nullable;
@@ -52,9 +53,9 @@ public final class KSectorLinkLayer
             int destinationY
         ) {
             return this.link(
-                new KVector2i(x, y),
+                KVectors.new2i(x, y),
                 linkedSector,
-                new KVector2i(destinationX, destinationY)
+                KVectors.new2i(destinationX, destinationY)
             );
         }
 
@@ -103,7 +104,7 @@ public final class KSectorLinkLayer
 
     @Override
     public @Nullable KSectorLinkData getOnPosition(int x, int y) {
-        return this.getOnPosition(new KVector2i(x, y));
+        return this.getOnPosition(KVectors.new2i(x, y));
     }
 
     @Override

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/tool/KLevelEntityLayerTool.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/tool/KLevelEntityLayerTool.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.level.layer.tool;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KLevelSector;
 import io.github.darthakiranihil.konna.level.entity.KLevelEntity;
 
@@ -39,7 +40,7 @@ public interface KLevelEntityLayerTool extends KReadableObjectLayerTool<List<KLe
      * @return This layer (for method chaining)
      */
     default KLevelEntityLayerTool placeEntity(int x, int y, final KLevelEntity entity) {
-        return this.placeEntity(new KVector2i(x, y), entity);
+        return this.placeEntity(KVectors.new2i(x, y), entity);
     }
 
     /**
@@ -58,7 +59,7 @@ public interface KLevelEntityLayerTool extends KReadableObjectLayerTool<List<KLe
      * @return This layer (for method chaining)
      */
     default KLevelEntityLayerTool removeEntity(int x, int y, final KLevelEntity entity) {
-        return this.removeEntity(new KVector2i(x, y), entity);
+        return this.removeEntity(KVectors.new2i(x, y), entity);
     }
 
     /**

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/tool/KLevelTransitionLayerTool.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/tool/KLevelTransitionLayerTool.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.level.layer.tool;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.layer.KLevelTransitionData;
 import io.github.darthakiranihil.konna.level.layer.KTransitionedLevelType;
 import org.jspecify.annotations.Nullable;
@@ -52,11 +53,11 @@ public interface KLevelTransitionLayerTool
         int destinationY
     ) {
         return this.makeTransition(
-            new KVector2i(x, y),
+            KVectors.new2i(x, y),
             levelDescriptor,
             levelType,
             destinationSector,
-            new KVector2i(destinationX, destinationY)
+            KVectors.new2i(destinationX, destinationY)
         );
     }
 
@@ -79,7 +80,7 @@ public interface KLevelTransitionLayerTool
 
     @Override
     default @Nullable KLevelTransitionData getOnPosition(int x, int y) {
-        return this.getOnPosition(new KVector2i(x, y));
+        return this.getOnPosition(KVectors.new2i(x, y));
     }
 
     @Override

--- a/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/tool/KSectorLinkLayerTool.java
+++ b/components/component-level/src/main/java/io/github/darthakiranihil/konna/level/layer/tool/KSectorLinkLayerTool.java
@@ -17,6 +17,7 @@
 package io.github.darthakiranihil.konna.level.layer.tool;
 
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KLevelSector;
 import io.github.darthakiranihil.konna.level.layer.KSectorLinkData;
 import org.jspecify.annotations.Nullable;
@@ -64,7 +65,7 @@ public interface KSectorLinkLayerTool extends KReadableObjectLayerTool<KSectorLi
 
     @Override
     default @Nullable KSectorLinkData getOnPosition(int x, int y) {
-        return this.getOnPosition(new KVector2i(x, y));
+        return this.getOnPosition(KVectors.new2i(x, y));
     }
 
     @Override

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/KLevelSectorPositiveTests.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/KLevelSectorPositiveTests.java
@@ -21,6 +21,7 @@ import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KStandardEventSystem;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.layer.*;
 import io.github.darthakiranihil.konna.level.layer.tool.KReachabilityAreaLayerTool;
 import io.github.darthakiranihil.konna.level.layer.tool.KSectorLinkLayerTool;
@@ -117,7 +118,7 @@ public class KLevelSectorPositiveTests extends KStandardTestClass {
         Assertions.assertEquals(tileInfo.getId(), sectorSlice.tile().getId());
         Assertions.assertNotNull(sectorSlice.sectorLink());
         Assertions.assertEquals(sector2.name(), sectorSlice.sectorLink().linkedSector().name());
-        Assertions.assertEquals(new KVector2i(1, 1), sectorSlice.sectorLink().destination());
+        Assertions.assertEquals(KVectors.new2i(1, 1), sectorSlice.sectorLink().destination());
         Assertions.assertEquals(sectorSlice, sector.getSlice(KVector2i.ZERO));
         var sectorLinkTool = sector.getTool(KSectorLinkLayerTool.class);
         Assertions.assertEquals(sectorSlice.sectorLink(), sectorLinkTool.getOnPosition(KVector2i.ZERO));
@@ -136,7 +137,7 @@ public class KLevelSectorPositiveTests extends KStandardTestClass {
         KTileInfo tileInfo2 = new KTileInfo("tt", 2, false, 16, Map.of());
         layer
             .getTool()
-            .placeTile(new KVector2i(0, 0), tileInfo1)
+            .placeTile(KVectors.new2i(0, 0), tileInfo1)
             .placeTile(0, 1, tileInfo1)
             .placeTile(0, 2, tileInfo1)
             .placeTile(1, 0, tileInfo2)
@@ -160,14 +161,14 @@ public class KLevelSectorPositiveTests extends KStandardTestClass {
 
         Assertions.assertTrue(
             reachTool.isReachable(
-                new KVector2i(0, 0),
-                new KVector2i(0, 2)
+                KVectors.new2i(0, 0),
+                KVectors.new2i(0, 2)
             )
         );
         Assertions.assertTrue(
             reachTool.isReachable(
-                new KVector2i(2, 0),
-                new KVector2i(2, 2)
+                KVectors.new2i(2, 0),
+                KVectors.new2i(2, 2)
             )
         );
         Assertions.assertTrue(
@@ -195,7 +196,7 @@ public class KLevelSectorPositiveTests extends KStandardTestClass {
 
         layer
             .getTool()
-            .placeTile(new KVector2i(0, 0), tileInfo1)
+            .placeTile(KVectors.new2i(0, 0), tileInfo1)
             .placeTile(0, 1, tileInfo1)
             .placeTile(0, 2, tileInfo1)
             .placeTile(1, 0, tileInfo2)
@@ -217,14 +218,14 @@ public class KLevelSectorPositiveTests extends KStandardTestClass {
         var reachTool = sector.getTool(KReachabilityAreaLayerTool.class);
         Assertions.assertFalse(
             reachTool.isReachable(
-                new KVector2i(0, 0),
-                new KVector2i(2, 2)
+                KVectors.new2i(0, 0),
+                KVectors.new2i(2, 2)
             )
         );
         Assertions.assertFalse(
             reachTool.isReachable(
-                new KVector2i(2, 0),
-                new KVector2i(0, 2)
+                KVectors.new2i(2, 0),
+                KVectors.new2i(0, 2)
             )
         );
         Assertions.assertFalse(
@@ -252,7 +253,7 @@ public class KLevelSectorPositiveTests extends KStandardTestClass {
 
         layer
             .getTool()
-            .placeTile(new KVector2i(0, 0), tileInfo1)
+            .placeTile(KVectors.new2i(0, 0), tileInfo1)
             .placeTile(0, 1, tileInfo1)
             .placeTile(0, 2, tileInfo1)
             .placeTile(1, 0, tileInfo2)
@@ -273,29 +274,29 @@ public class KLevelSectorPositiveTests extends KStandardTestClass {
         );
         var reachTool = sector.getTool(KReachabilityAreaLayerTool.class);
         Assertions.assertFalse(
-            reachTool.isReachable(new KVector2i(-1, 0), new KVector2i(0, 1))
+            reachTool.isReachable(KVectors.new2i(-1, 0), KVectors.new2i(0, 1))
         );
         Assertions.assertFalse(
-            reachTool.isReachable(new KVector2i(3, 0), new KVector2i(0, 1))
+            reachTool.isReachable(KVectors.new2i(3, 0), KVectors.new2i(0, 1))
         );
         Assertions.assertFalse(
-            reachTool.isReachable(new KVector2i(0, -1), new KVector2i(0, 1))
+            reachTool.isReachable(KVectors.new2i(0, -1), KVectors.new2i(0, 1))
         );
         Assertions.assertFalse(
-            reachTool.isReachable(new KVector2i(0, 3), new KVector2i(0, 1))
+            reachTool.isReachable(KVectors.new2i(0, 3), KVectors.new2i(0, 1))
         );
 
         Assertions.assertFalse(
-            reachTool.isReachable(new KVector2i(0, 1), new KVector2i(-1, 0))
+            reachTool.isReachable(KVectors.new2i(0, 1), KVectors.new2i(-1, 0))
         );
         Assertions.assertFalse(
-            reachTool.isReachable(new KVector2i(0, 1), new KVector2i(3, 0))
+            reachTool.isReachable(KVectors.new2i(0, 1), KVectors.new2i(3, 0))
         );
         Assertions.assertFalse(
-            reachTool.isReachable(new KVector2i(0, 1), new KVector2i(0, -1))
+            reachTool.isReachable(KVectors.new2i(0, 1), KVectors.new2i(0, -1))
         );
         Assertions.assertFalse(
-            reachTool.isReachable(new KVector2i(0, 1), new KVector2i(0, 3))
+            reachTool.isReachable(KVectors.new2i(0, 1), KVectors.new2i(0, 3))
         );
 
     }
@@ -312,7 +313,7 @@ public class KLevelSectorPositiveTests extends KStandardTestClass {
 
         layer
             .getTool()
-            .placeTile(new KVector2i(0, 0), tileInfo1)
+            .placeTile(KVectors.new2i(0, 0), tileInfo1)
             .placeTile(0, 1, tileInfo1)
             .placeTile(0, 2, tileInfo1)
             .placeTile(1, 0, tileInfo2)
@@ -333,7 +334,7 @@ public class KLevelSectorPositiveTests extends KStandardTestClass {
         );
         var reachTool = sector.getTool(KReachabilityAreaLayerTool.class);
         Assertions.assertFalse(
-            reachTool.isReachable(new KVector2i(0, 0), new KVector2i(1, 1))
+            reachTool.isReachable(KVectors.new2i(0, 0), KVectors.new2i(1, 1))
         );
         Assertions.assertFalse(
             reachTool.isReachable(0, 0, 1, 1)

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/entity/KLevelEntityPositiveTests.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/entity/KLevelEntityPositiveTests.java
@@ -22,6 +22,7 @@ import io.github.darthakiranihil.konna.core.message.KStandardEventSystem;
 import io.github.darthakiranihil.konna.core.struct.KPair;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.core.util.KThreadUtils;
 import io.github.darthakiranihil.konna.level.KLevelSector;
 import io.github.darthakiranihil.konna.level.KTileInfo;
@@ -105,12 +106,12 @@ public class KLevelEntityPositiveTests extends KStandardTestClass {
         controllableEntity.setPosition(sector, KVector2i.ZERO);
         mel.getTool().placeEntity(0, 0, controllableEntity);
 
-        controllableEntity.setNextMoveDirection(new KVector2i(1, 0));
+        controllableEntity.setNextMoveDirection(KVectors.new2i(1, 0));
         controllableEntity.move();
 
         KThreadUtils.sleepForSeconds(1);
         Assertions.assertEquals(
-            new KPair<>(new KVector2i(1, 0), sector),
+            new KPair<>(KVectors.new2i(1, 0), sector),
             controllableEntity.getPosition()
         );
 
@@ -152,7 +153,7 @@ public class KLevelEntityPositiveTests extends KStandardTestClass {
         mel.getTool().placeEntity(0, 0, controllableEntity);
 
         var previousPosition = controllableEntity.getPosition();
-        controllableEntity.setNextMoveDirection(new KVector2i(1, 0));
+        controllableEntity.setNextMoveDirection(KVectors.new2i(1, 0));
         controllableEntity.move();
         KThreadUtils.sleepForSeconds(1);
         Assertions.assertEquals(
@@ -261,11 +262,11 @@ public class KLevelEntityPositiveTests extends KStandardTestClass {
         controllableEntity.setPosition(sector, KVector2i.ZERO);
         mel.getTool().placeEntity(0, 0, controllableEntity);
 
-        controllableEntity.setNextMoveDirection(new KVector2i(-1, 0));
+        controllableEntity.setNextMoveDirection(KVectors.new2i(-1, 0));
         controllableEntity.move();
         KThreadUtils.sleepForSeconds(1);
         Assertions.assertEquals(
-            new KPair<>(new KVector2i(0, 1), sector2),
+            new KPair<>(KVectors.new2i(0, 1), sector2),
             controllableEntity.getPosition()
         );
 
@@ -329,7 +330,7 @@ public class KLevelEntityPositiveTests extends KStandardTestClass {
         mel.getTool().placeEntity(0, 0, controllableEntity);
 
         var previousPosition = controllableEntity.getPosition();
-        controllableEntity.setNextMoveDirection(new KVector2i(-1, 0));
+        controllableEntity.setNextMoveDirection(KVectors.new2i(-1, 0));
         controllableEntity.move();
         KThreadUtils.sleepForSeconds(1);
         Assertions.assertEquals(
@@ -374,7 +375,7 @@ public class KLevelEntityPositiveTests extends KStandardTestClass {
         mel.getTool().placeEntity(0, 0, controllableEntity);
 
         var previousPosition = controllableEntity.getPosition();
-        controllableEntity.setNextMoveDirection(new KVector2i(-1, 0));
+        controllableEntity.setNextMoveDirection(KVectors.new2i(-1, 0));
         controllableEntity.move();
         KThreadUtils.sleepForSeconds(1);
         Assertions.assertEquals(
@@ -424,7 +425,7 @@ public class KLevelEntityPositiveTests extends KStandardTestClass {
         mel.getTool().placeEntity(0, 0, controllableEntity);
 
         var previousPosition = controllableEntity.getPosition();
-        controllableEntity.setNextMoveDirection(new KVector2i(0, 1));
+        controllableEntity.setNextMoveDirection(KVectors.new2i(0, 1));
         controllableEntity.move();
         KThreadUtils.sleepForSeconds(1);
         Assertions.assertEquals(
@@ -499,7 +500,7 @@ public class KLevelEntityPositiveTests extends KStandardTestClass {
         mel.getTool().placeEntity(0, 0, controllableEntity);
 
         var previousPosition = controllableEntity.getPosition();
-        controllableEntity.setNextMoveDirection(new KVector2i(-1, 0));
+        controllableEntity.setNextMoveDirection(KVectors.new2i(-1, 0));
         controllableEntity.move();
         KThreadUtils.sleepForSeconds(1);
         Assertions.assertEquals(

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestController.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestController.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.impl;
 
 import io.github.darthakiranihil.konna.core.io.KAssetDefinition;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.entity.KAutonomousEntityController;
 import io.github.darthakiranihil.konna.level.entity.KAutonomousEntityControllerParam;
 import io.github.darthakiranihil.konna.level.entity.KLevelEntity;
@@ -41,7 +42,7 @@ public class TestController extends KAutonomousEntityController {
 
     @Override
     public KVector2i getNextMoveDirection() {
-        return new KVector2i(1, 0);
+        return KVectors.new2i(1, 0);
     }
 
     public int getTest() {

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/layer/KHeightLayerPositiveTests.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/layer/KHeightLayerPositiveTests.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.layer;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,11 +56,11 @@ public class KHeightLayerPositiveTests extends KStandardTestClass {
             layer.getOnPosition(KVector2i.ZERO)
         );
 
-        layer.getTool().setHeight(new KVector2i(1, 1), 2);
+        layer.getTool().setHeight(KVectors.new2i(1, 1), 2);
         Assertions.assertEquals(2, layer.getOnPosition(1, 1));
         Assertions.assertEquals(
             layer.getOnPosition(1, 1),
-            layer.getOnPosition(new KVector2i(1, 1))
+            layer.getOnPosition(KVectors.new2i(1, 1))
         );
 
     }

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/layer/KReachabilityLayerPositiveTests.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/layer/KReachabilityLayerPositiveTests.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.layer;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KTileInfo;
 import io.github.darthakiranihil.konna.level.layer.tool.KReachabilityAreaLayerTool;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
@@ -38,7 +39,7 @@ public class KReachabilityLayerPositiveTests extends KStandardTestClass {
 
         layer
             .getTool()
-            .placeTile(new KVector2i(0, 0), tileInfo1)
+            .placeTile(KVectors.new2i(0, 0), tileInfo1)
             .placeTile(0, 1, tileInfo1)
             .placeTile(0, 2, tileInfo1)
             .placeTile(1, 0, tileInfo2)
@@ -68,14 +69,14 @@ public class KReachabilityLayerPositiveTests extends KStandardTestClass {
 
         Assertions.assertTrue(
             this.tool.isReachable(
-                new KVector2i(0, 0),
-                new KVector2i(0, 2)
+                KVectors.new2i(0, 0),
+                KVectors.new2i(0, 2)
             )
         );
         Assertions.assertTrue(
             this.tool.isReachable(
-                new KVector2i(2, 0),
-                new KVector2i(2, 2)
+                KVectors.new2i(2, 0),
+                KVectors.new2i(2, 2)
             )
         );
         Assertions.assertTrue(
@@ -96,14 +97,14 @@ public class KReachabilityLayerPositiveTests extends KStandardTestClass {
 
         Assertions.assertFalse(
             this.tool.isReachable(
-                new KVector2i(0, 0),
-                new KVector2i(2, 2)
+                KVectors.new2i(0, 0),
+                KVectors.new2i(2, 2)
             )
         );
         Assertions.assertFalse(
             this.tool.isReachable(
-                new KVector2i(2, 0),
-                new KVector2i(0, 2)
+                KVectors.new2i(2, 0),
+                KVectors.new2i(0, 2)
             )
         );
         Assertions.assertFalse(
@@ -123,29 +124,29 @@ public class KReachabilityLayerPositiveTests extends KStandardTestClass {
     public void testUnreachableBecauseOfOutOfBounds() {
 
         Assertions.assertFalse(
-            this.tool.isReachable(new KVector2i(-1, 0), new KVector2i(0, 1))
+            this.tool.isReachable(KVectors.new2i(-1, 0), KVectors.new2i(0, 1))
         );
         Assertions.assertFalse(
-            this.tool.isReachable(new KVector2i(3, 0), new KVector2i(0, 1))
+            this.tool.isReachable(KVectors.new2i(3, 0), KVectors.new2i(0, 1))
         );
         Assertions.assertFalse(
-            this.tool.isReachable(new KVector2i(0, -1), new KVector2i(0, 1))
+            this.tool.isReachable(KVectors.new2i(0, -1), KVectors.new2i(0, 1))
         );
         Assertions.assertFalse(
-            this.tool.isReachable(new KVector2i(0, 3), new KVector2i(0, 1))
+            this.tool.isReachable(KVectors.new2i(0, 3), KVectors.new2i(0, 1))
         );
 
         Assertions.assertFalse(
-            this.tool.isReachable(new KVector2i(0, 1), new KVector2i(-1, 0))
+            this.tool.isReachable(KVectors.new2i(0, 1), KVectors.new2i(-1, 0))
         );
         Assertions.assertFalse(
-            this.tool.isReachable(new KVector2i(0, 1), new KVector2i(3, 0))
+            this.tool.isReachable(KVectors.new2i(0, 1), KVectors.new2i(3, 0))
         );
         Assertions.assertFalse(
-            this.tool.isReachable(new KVector2i(0, 1), new KVector2i(0, -1))
+            this.tool.isReachable(KVectors.new2i(0, 1), KVectors.new2i(0, -1))
         );
         Assertions.assertFalse(
-            this.tool.isReachable(new KVector2i(0, 1), new KVector2i(0, 3))
+            this.tool.isReachable(KVectors.new2i(0, 1), KVectors.new2i(0, 3))
         );
 
     }
@@ -154,7 +155,7 @@ public class KReachabilityLayerPositiveTests extends KStandardTestClass {
     public void testUnreachableBecauseOfImpassableTile() {
 
         Assertions.assertFalse(
-            this.tool.isReachable(new KVector2i(0, 0), new KVector2i(1, 1))
+            this.tool.isReachable(KVectors.new2i(0, 0), KVectors.new2i(1, 1))
         );
         Assertions.assertFalse(
             this.tool.isReachable(0, 0, 1, 1)
@@ -170,7 +171,7 @@ public class KReachabilityLayerPositiveTests extends KStandardTestClass {
 
         layer
             .getTool()
-            .placeTile(new KVector2i(0, 0), tileInfo1)
+            .placeTile(KVectors.new2i(0, 0), tileInfo1)
             .placeTile(0, 1, tileInfo1)
             .placeTile(0, 2, tileInfo1)
             .placeTile(1, 0, tileInfo1)
@@ -190,7 +191,7 @@ public class KReachabilityLayerPositiveTests extends KStandardTestClass {
         var rl = new KReachabilityAreaLayer(layer, hl).getTool();
 
         Assertions.assertFalse(rl.isReachable(0, 0, 2, 2));
-        Assertions.assertFalse(rl.isReachable(new KVector2i(0, 0), new KVector2i(2, 2)));
+        Assertions.assertFalse(rl.isReachable(KVectors.new2i(0, 0), KVectors.new2i(2, 2)));
 
     }
 }

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/layer/KTileLayerPositiveTests.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/layer/KTileLayerPositiveTests.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.layer;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.core.util.KReflectionUtils;
 import io.github.darthakiranihil.konna.level.KTileInfo;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
@@ -62,11 +63,11 @@ public class KTileLayerPositiveTests extends KStandardTestClass {
         Assertions.assertEquals(t00, tool.getOnPosition(0, 0));
         Assertions.assertEquals(t00, tool.getOnPosition(KVector2i.ZERO));
         Assertions.assertEquals(t01, tool.getOnPosition(0, 1));
-        Assertions.assertEquals(t01, tool.getOnPosition(new KVector2i(0, 1)));
+        Assertions.assertEquals(t01, tool.getOnPosition(KVectors.new2i(0, 1)));
         Assertions.assertEquals(t10, tool.getOnPosition(1, 0));
-        Assertions.assertEquals(t10, tool.getOnPosition(new KVector2i(1, 0)));
+        Assertions.assertEquals(t10, tool.getOnPosition(KVectors.new2i(1, 0)));
         Assertions.assertEquals(t11, tool.getOnPosition(1, 1));
-        Assertions.assertEquals(t11, tool.getOnPosition(new KVector2i(1, 1)));
+        Assertions.assertEquals(t11, tool.getOnPosition(KVectors.new2i(1, 1)));
     }
 
     @Test
@@ -97,16 +98,16 @@ public class KTileLayerPositiveTests extends KStandardTestClass {
         Assertions.assertEquals(KSize.squared(2), layer.getSize());
 
         var tool = layer.getTool();
-        tool.placeTile(new KVector2i(0, 0), tileInfo);
-        tool.placeTile(new KVector2i(0, 0), tileInfo);
-        tool.placeTile(new KVector2i(0, 1), tileInfo);
-        tool.placeTile(new KVector2i(1, 0), tileInfo);
-        tool.placeTile(new KVector2i(1, 1), tileInfo);
+        tool.placeTile(KVectors.new2i(0, 0), tileInfo);
+        tool.placeTile(KVectors.new2i(0, 0), tileInfo);
+        tool.placeTile(KVectors.new2i(0, 1), tileInfo);
+        tool.placeTile(KVectors.new2i(1, 0), tileInfo);
+        tool.placeTile(KVectors.new2i(1, 1), tileInfo);
 
-        KTileInfo t00 = layer.getOnPosition(new KVector2i(0, 0));
-        KTileInfo t01 = layer.getOnPosition(new KVector2i(0, 1));
-        KTileInfo t10 = layer.getOnPosition(new KVector2i(1, 0));
-        KTileInfo t11 = layer.getOnPosition(new KVector2i(1, 1));
+        KTileInfo t00 = layer.getOnPosition(KVectors.new2i(0, 0));
+        KTileInfo t01 = layer.getOnPosition(KVectors.new2i(0, 1));
+        KTileInfo t10 = layer.getOnPosition(KVectors.new2i(1, 0));
+        KTileInfo t11 = layer.getOnPosition(KVectors.new2i(1, 1));
 
         Assertions.assertNotNull(t00);
         Assertions.assertNotNull(t01);

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/layer/KVisitedPlacesLayerPositiveTests.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/layer/KVisitedPlacesLayerPositiveTests.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.layer;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ public class KVisitedPlacesLayerPositiveTests extends KStandardTestClass {
         Assertions.assertFalse(tool.isVisited(0, 0));
         Assertions.assertEquals(
             tool.isVisited(0, 0),
-            tool.isVisited(new KVector2i(0, 0))
+            tool.isVisited(KVectors.new2i(0, 0))
         );
 
 
@@ -52,14 +53,14 @@ public class KVisitedPlacesLayerPositiveTests extends KStandardTestClass {
         Assertions.assertTrue(tool.isVisited(0, 0));
         Assertions.assertEquals(
             tool.isVisited(0, 0),
-            tool.isVisited(new KVector2i(0, 0))
+            tool.isVisited(KVectors.new2i(0, 0))
         );
 
-        tool.visitPlace(new KVector2i(1, 1));
+        tool.visitPlace(KVectors.new2i(1, 1));
         Assertions.assertTrue(tool.isVisited(1, 1));
         Assertions.assertEquals(
             tool.isVisited(1, 1),
-            tool.isVisited(new KVector2i(1, 1))
+            tool.isVisited(KVectors.new2i(1, 1))
         );
 
     }

--- a/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/service/KLevelEntityManagementServiceTests.java
+++ b/components/component-level/src/test/java/io/github/darthakiranihil/konna/level/service/KLevelEntityManagementServiceTests.java
@@ -31,6 +31,7 @@ import io.github.darthakiranihil.konna.core.io.KMapAssetDefinition;
 import io.github.darthakiranihil.konna.core.message.*;
 import io.github.darthakiranihil.konna.core.object.KObjectRegistry;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.core.struct.ref.KBooleanReference;
 import io.github.darthakiranihil.konna.core.util.KReflectionUtils;
 import io.github.darthakiranihil.konna.level.KLevel;
@@ -231,16 +232,16 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 var id = (UUID)  controllables.keySet().toArray()[0];
                 body.clear();
                 body.put("entity_id", id);
-                body.put("direction", new KVector2i(0, 1));
+                body.put("direction", KVectors.new2i(0, 1));
                 messageSystem.deliverMessageSync(KMessage.regular("setDirectionForControllableEntity", body));
                 messageSystem.deliverMessageSync(KMessage.regular("moveAllEntities", new KUniversalMap()));
                 frameTaskExecutor.executeScheduledTasks(KFrameEvent.FRAME_FINISHED);
-                Assertions.assertEquals(new KVector2i(2, 1),  controllables.get(id).getPosition().first());
+                Assertions.assertEquals(KVectors.new2i(2, 1),  controllables.get(id).getPosition().first());
 
                 var autoId = (UUID) autonomouses.keySet().toArray()[0];
-                Assertions.assertEquals(new KVector2i(1, 0),  autonomouses.get(autoId).getPosition().first());
+                Assertions.assertEquals(KVectors.new2i(1, 0),  autonomouses.get(autoId).getPosition().first());
                 var staticId = (UUID) statics.keySet().toArray()[0];
-                Assertions.assertEquals(new KVector2i(0, 1),  statics.get(staticId).getPosition().first());
+                Assertions.assertEquals(KVectors.new2i(0, 1),  statics.get(staticId).getPosition().first());
             }
         }
 
@@ -310,7 +311,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 body.put("name", "synthetic");
                 body.put("descriptor", "synthetic");
                 body.put("sector_name", "mf1");
-                body.put("position", new KVector2i(2, 2));
+                body.put("position", KVectors.new2i(2, 2));
                 body.put("controller", TestController.class);
                 body.put("params", new KMapAssetDefinition(Map.of("test", 42069)));
 
@@ -323,7 +324,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                         .anyMatch(x -> {
                             var pos = x.getPosition();
                             return
-                                pos.first().equals(new KVector2i(2, 2))
+                                pos.first().equals(KVectors.new2i(2, 2))
                                     &&  pos.second().name().equals("mf1")
                                     &&  x.name().equals("synthetic")
                                     &&  x.getDescriptor().equals("synthetic");
@@ -398,7 +399,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 body.put("name", "synthetic");
                 body.put("descriptor", "synthetic");
                 body.put("sector_name", "mf1");
-                body.put("position", new KVector2i(2, 2));
+                body.put("position", KVectors.new2i(2, 2));
                 body.put("controller", TestControllerWithoutValidator.class);
                 body.put("params", new KMapAssetDefinition(Map.of("test", 42069)));
 
@@ -411,7 +412,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                         .anyMatch(x -> {
                             var pos = x.getPosition();
                             return
-                                pos.first().equals(new KVector2i(2, 2))
+                                pos.first().equals(KVectors.new2i(2, 2))
                                     &&  pos.second().name().equals("mf1")
                                     &&  x.name().equals("synthetic")
                                     &&  x.getDescriptor().equals("synthetic");
@@ -485,7 +486,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 body.put("name", "synthetic");
                 body.put("descriptor", "synthetic");
                 body.put("sector_name", "mf1");
-                body.put("position", new KVector2i(2, 2));
+                body.put("position", KVectors.new2i(2, 2));
                 body.put("controller", FalseValidatedController.class);
                 body.put("params", new KMapAssetDefinition(Map.of("test", 42069)));
 
@@ -498,7 +499,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                         .anyMatch(x -> {
                             var pos = x.getPosition();
                             return
-                                pos.first().equals(new KVector2i(2, 2))
+                                pos.first().equals(KVectors.new2i(2, 2))
                                     &&  pos.second().name().equals("mf1")
                                     &&  x.name().equals("synthetic")
                                     &&  x.getDescriptor().equals("synthetic");
@@ -571,7 +572,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 body.put("name", "synthetic");
                 body.put("descriptor", "synthetic");
                 body.put("sector_name", "mf1");
-                body.put("position", new KVector2i(2, 2));
+                body.put("position", KVectors.new2i(2, 2));
                 body.put("controller", TestController.class);
                 body.put("params", new KMapAssetDefinition(Map.of("test2", 42069)));
 
@@ -722,7 +723,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 body.put("name", "synthetic");
                 body.put("descriptor", "synthetic");
                 body.put("sector_name", "mf1");
-                body.put("position", new KVector2i(2, 2));
+                body.put("position", KVectors.new2i(2, 2));
 
                 messageSystem.deliverMessageSync(KMessage.regular("createControllableEntity", body));
                 Assertions.assertEquals(2, controllables.size());
@@ -733,7 +734,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                         .anyMatch(x -> {
                             var pos = x.getPosition();
                             return
-                                pos.first().equals(new KVector2i(2, 2))
+                                pos.first().equals(KVectors.new2i(2, 2))
                                     &&  pos.second().name().equals("mf1")
                                     &&  x.name().equals("synthetic")
                                     &&  x.getDescriptor().equals("synthetic");
@@ -885,7 +886,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 body.put("name", "synthetic");
                 body.put("descriptor", "synthetic");
                 body.put("sector_name", "mf1");
-                body.put("position", new KVector2i(2, 2));
+                body.put("position", KVectors.new2i(2, 2));
 
                 messageSystem.deliverMessageSync(KMessage.regular("createStaticEntity", body));
                 Assertions.assertEquals(2, statics.size());
@@ -896,7 +897,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                         .anyMatch(x -> {
                             var pos = x.getPosition();
                             return
-                                pos.first().equals(new KVector2i(2, 2))
+                                pos.first().equals(KVectors.new2i(2, 2))
                                     &&  pos.second().name().equals("mf1")
                                     &&  x.name().equals("synthetic")
                                     &&  x.getDescriptor().equals("synthetic");
@@ -1048,7 +1049,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 body.put("name", "synthetic");
                 body.put("descriptor", "synthetic");
                 body.put("sector_name", "mf1");
-                body.put("position", new KVector2i(999, 99));
+                body.put("position", KVectors.new2i(999, 99));
 
                 messageSystem.deliverMessageSync(KMessage.regular("createStaticEntity", body));
                 messageSystem.deliverMessageSync(KMessage.regular("createControllableEntity", body));
@@ -1126,7 +1127,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 body.put("name", "synthetic");
                 body.put("descriptor", "synthetic");
                 body.put("sector_name", "mf99");
-                body.put("position", new KVector2i(1, 1));
+                body.put("position", KVectors.new2i(1, 1));
 
                 messageSystem.deliverMessageSync(KMessage.regular("createStaticEntity", body));
                 messageSystem.deliverMessageSync(KMessage.regular("createControllableEntity", body));
@@ -1277,7 +1278,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 var previousPosition = controllables.get(id).getPosition();
 
                 body.put("entity_id", UUID.randomUUID());
-                body.put("direction", new KVector2i(0, 1));
+                body.put("direction", KVectors.new2i(0, 1));
                 messageSystem.deliverMessageSync(KMessage.regular("setDirectionForControllableEntity", body));
                 messageSystem.deliverMessageSync(KMessage.regular("moveAllEntities", new KUniversalMap()));
                 frameTaskExecutor.executeScheduledTasks(KFrameEvent.FRAME_FINISHED);
@@ -1285,9 +1286,9 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 Assertions.assertEquals(previousPosition,  controllables.get(id).getPosition());
 
                 var autoId = (UUID) autonomouses.keySet().toArray()[0];
-                Assertions.assertEquals(new KVector2i(1, 0),  autonomouses.get(autoId).getPosition().first());
+                Assertions.assertEquals(KVectors.new2i(1, 0),  autonomouses.get(autoId).getPosition().first());
                 var staticId = (UUID) statics.keySet().toArray()[0];
-                Assertions.assertEquals(new KVector2i(0, 1),  statics.get(staticId).getPosition().first());
+                Assertions.assertEquals(KVectors.new2i(0, 1),  statics.get(staticId).getPosition().first());
             }
         }
 
@@ -1354,7 +1355,7 @@ public class KLevelEntityManagementServiceTests extends KStandardTestClass {
                 body.put("name", "synthetic");
                 body.put("descriptor", "synthetic");
                 body.put("sector_name", "mf99");
-                body.put("position", new KVector2i(1, 1));
+                body.put("position", KVectors.new2i(1, 1));
 
                 messageSystem.deliverMessageSync(KMessage.regular("createStaticEntity", body));
                 messageSystem.deliverMessageSync(KMessage.regular("createControllableEntity", body));

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -97,6 +97,9 @@
     <suppress checks="MagicNumber" files="KGeometryUtils.java"/>
     <suppress checks="MagicNumber" files="KTextureMaker.java"/>
     <suppress checks="MagicNumber" files="KRaycastLevelObserver.java"/>
+    <suppress checks="MagicNumber" files="KVector2f.java"/>
+    <suppress checks="MagicNumber" files="KVector2i.java"/>
+    <suppress checks="MagicNumber" files="KVector4f.java"/>
 
 
     <suppress checks="ParameterName" files="KStbImageLwjgl.java"/>

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KSize.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KSize.java
@@ -47,7 +47,7 @@ public record KSize(
      * @return Int vector representation of the size
      */
     public KVector2i asIntVector() {
-        return new KVector2i(this.width, this.height);
+        return KVectors.new2i(this.width, this.height);
     }
 
     /**

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KSize.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KSize.java
@@ -54,7 +54,7 @@ public record KSize(
      * @return Float vector representation of the size
      */
     public KVector2f asFloatVector() {
-        return new KVector2f(this.width, this.height);
+        return KVectors.new2f(this.width, this.height);
     }
 
     /**

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KStructUtils.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KStructUtils.java
@@ -45,7 +45,7 @@ public final class KStructUtils extends KUninstantiable {
         int count = x.length == y.length ? x.length : Math.min(x.length, y.length);
         KVector2i[] furled = new KVector2i[count];
         for (int i = 0; i < count; i++) {
-            furled[i] = new KVector2i(x[i], y[i]);
+            furled[i] = KVectors.new2i(x[i], y[i]);
         }
         return furled;
     }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2f.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2f.java
@@ -16,6 +16,10 @@
 
 package io.github.darthakiranihil.konna.core.struct;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Representation of a 2d vector, which coordinates are represented with floats.
  * @param x X coordinate
@@ -29,6 +33,9 @@ public record KVector2f(
     float y
 ) {
 
+    // todo: soft references
+    private static final Map<Integer, KVector2f> INSTANCES;
+
     /**
      * Zero vector - (0,0).
      */
@@ -37,5 +44,21 @@ public record KVector2f(
      * Unit vector - (1,1).
      */
     public static final KVector2f ONE = new KVector2f(1.0f, 1.0f);
+
+    static {
+        INSTANCES = new ConcurrentHashMap<>();
+
+        INSTANCES.put(ZERO.hashCode(), ZERO);
+        INSTANCES.put(ONE.hashCode(), ONE);
+    }
+
+    static KVector2f create(float x, float y) {
+        int hash = Objects.hash(x, y);
+        if (!INSTANCES.containsKey(hash)) {
+            INSTANCES.put(hash, new KVector2f(x, y));
+        }
+
+        return INSTANCES.get(hash);
+    }
 
 }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2f.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2f.java
@@ -16,22 +16,33 @@
 
 package io.github.darthakiranihil.konna.core.struct;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Representation of a 2d vector, which coordinates are represented with floats.
- * @param x X coordinate
- * @param y Y coordinate
+ * Representation of a 2D vector, which coordinates are represented with floats.
  *
  * @since 0.3.0
  * @author Darth Akira Nihil
  */
-public record KVector2f(
-    float x,
-    float y
-) {
+public final class KVector2f {
+
+    private final float x;
+    private final float y;
+
+    private KVector2f(float x, float y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    private static int hash(float x, float y) {
+        int result = 1;
+        result = 31 * result + Float.floatToIntBits(x);
+        result = 33 * result + Float.floatToIntBits(y);
+        return result;
+    }
 
     // todo: soft references
     private static final Map<Integer, KVector2f> INSTANCES;
@@ -52,13 +63,52 @@ public record KVector2f(
         INSTANCES.put(ONE.hashCode(), ONE);
     }
 
+
     static KVector2f create(float x, float y) {
-        int hash = Objects.hash(x, y);
+        int hash = KVector2f.hash(x, y);
         if (!INSTANCES.containsKey(hash)) {
             INSTANCES.put(hash, new KVector2f(x, y));
         }
 
-        return INSTANCES.get(hash);
+        KVector2f instance = INSTANCES.get(hash);
+        return instance.x == x && instance.y == y
+            ? instance
+            : new KVector2f(x, y);
+
     }
 
+    /**
+     * @return X coordinate
+     */
+    public float x() {
+        return this.x;
+    }
+
+    /**
+     * @return Y coordinate
+     */
+    public float y() {
+        return this.y;
+    }
+
+    @Override
+    public boolean equals(@Nullable final Object object) {
+        if (object == null || this.getClass() != object.getClass()) {
+            return false;
+        }
+        KVector2f kVector2f = (KVector2f) object;
+        return
+                Float.compare(this.x, kVector2f.x) == 0
+            &&  Float.compare(this.y, kVector2f.y) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return KVector2f.hash(this.x, this.y);
+    }
+
+    @Override
+    public String toString() {
+        return "KVector2f{" + "x=" + this.x + ", y=" + this.y + '}';
+    }
 }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
@@ -142,7 +142,7 @@ public final class KVector2i {
     }
 
     @Override
-    public boolean equals(@Nullable Object object) {
+    public boolean equals(final @Nullable Object object) {
         if (object == null || this.getClass() != object.getClass()) {
             return false;
         }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
@@ -16,22 +16,35 @@
 
 package io.github.darthakiranihil.konna.core.struct;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Representation of a 2d vector, which coordinates are represented with ints.
- * @param x X coordinate
- * @param y Y coordinate
+ * Representation of a 2D vector, which coordinates are represented with ints.
  *
  * @since 0.3.0
  * @author Darth Akira Nihil
  */
-public record KVector2i(
-    int x,
-    int y
-) {
+public final class KVector2i {
+
+    private final int x;
+    private final int y;
+
+    private KVector2i(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    private static int hash(int x, int y) {
+        int result = 1;
+        result = result * 31 + x;
+        result = result * 33 + y;
+        return result;
+    }
+
     // todo: soft references
     private static final Map<Integer, KVector2i> INSTANCES;
 
@@ -78,12 +91,29 @@ public record KVector2i(
     }
 
     static KVector2i create(int x, int y) {
-        int hash = Objects.hash(x, y);
+        int hash = KVector2i.hash(x, y);
         if (!INSTANCES.containsKey(hash)) {
             INSTANCES.put(hash, new KVector2i(x, y));
         }
 
-        return INSTANCES.get(hash);
+        KVector2i instance = INSTANCES.get(hash);
+        return instance.x == x && instance.y == y
+            ? instance
+            : new KVector2i(x, y);
+    }
+
+    /**
+     * @return X coordinate
+     */
+    public int x() {
+        return this.x;
+    }
+
+    /**
+     * @return Y coordinate
+     */
+    public int y() {
+        return this.y;
     }
 
     /**
@@ -111,4 +141,24 @@ public record KVector2i(
     public KVector2i negate() {
         return KVector2i.create(-this.x, -this.y);
     }
+
+    @Override
+    public boolean equals(@Nullable Object object) {
+        if (object == null || this.getClass() != object.getClass()) {
+            return false;
+        }
+        KVector2i kVector2i = (KVector2i) object;
+        return this.x == kVector2i.x && this.y == kVector2i.y;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.x, this.y);
+    }
+
+    @Override
+    public String toString() {
+        return "KVector2i{" + "x=" + this.x + ", y=" + this.y + '}';
+    }
+
 }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
@@ -16,6 +16,10 @@
 
 package io.github.darthakiranihil.konna.core.struct;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Representation of a 2d vector, which coordinates are represented with ints.
  * @param x X coordinate
@@ -28,6 +32,8 @@ public record KVector2i(
     int x,
     int y
 ) {
+    // todo: soft references
+    private static final Map<Integer, KVector2i> INSTANCES;
 
     /**
      * Zero vector - (0,0).
@@ -58,6 +64,27 @@ public record KVector2i(
      * Vector representation of down direction - (0, -1).
      */
     public static final KVector2i DOWN = new KVector2i(0, -1);
+
+    static {
+        INSTANCES = new ConcurrentHashMap<>();
+
+        INSTANCES.put(ZERO.hashCode(), ZERO);
+        INSTANCES.put(ONE.hashCode(), ONE);
+        INSTANCES.put(MINUS_ONE.hashCode(), MINUS_ONE);
+        INSTANCES.put(RIGHT.hashCode(), RIGHT);
+        INSTANCES.put(LEFT.hashCode(), LEFT);
+        INSTANCES.put(UP.hashCode(), UP);
+        INSTANCES.put(DOWN.hashCode(), DOWN);
+    }
+
+    static KVector2i create(int x, int y) {
+        int hash = Objects.hash(x, y);
+        if (!INSTANCES.containsKey(hash)) {
+            INSTANCES.put(hash, new KVector2i(x, y));
+        }
+
+        return INSTANCES.get(hash);
+    }
 
     /**
      * Adds a vector to this vector.

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
@@ -92,7 +92,7 @@ public record KVector2i(
      * @return Result vector
      */
     public KVector2i add(final KVector2i other) {
-        return new KVector2i(this.x + other.x(), this.y + other.y());
+        return KVector2i.create(this.x + other.x(), this.y + other.y());
     }
 
     /**
@@ -101,7 +101,7 @@ public record KVector2i(
      * @return Result vector
      */
     public KVector2i subtract(final KVector2i other) {
-        return new KVector2i(this.x - other.x(), this.y - other.y());
+        return KVector2i.create(this.x - other.x(), this.y - other.y());
     }
 
     /**
@@ -109,6 +109,6 @@ public record KVector2i(
      * @return A new vector with negated coordinates of this vector
      */
     public KVector2i negate() {
-        return new KVector2i(-this.x, -this.y);
+        return KVector2i.create(-this.x, -this.y);
     }
 }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector2i.java
@@ -19,7 +19,6 @@ package io.github.darthakiranihil.konna.core.struct;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -153,7 +152,7 @@ public final class KVector2i {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.x, this.y);
+        return KVector2i.hash(this.x, this.y);
     }
 
     @Override

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector4f.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector4f.java
@@ -16,26 +16,31 @@
 
 package io.github.darthakiranihil.konna.core.struct;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Representation of a 4d vector, which coordinates are represented with floats.
- * @param x X coordinate
- * @param y Y coordinate
- * @param z Z coordinate
- * @param w W coordinate
+ * Representation of a 4D vector, which coordinates are represented with floats.
  *
  * @since 0.3.0
  * @author Darth Akira Nihil
  */
-public record KVector4f(
-    float x,
-    float y,
-    float z,
-    float w
-) {
+public final class KVector4f {
+
+    private final float x;
+    private final float y;
+    private final float z;
+    private final float w;
+
+    private KVector4f(float x, float y, float z, float w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
 
     // todo: soft references
     private static final Map<Integer, KVector4f> INSTANCES;
@@ -63,5 +68,57 @@ public record KVector4f(
         }
 
         return INSTANCES.get(hash);
+    }
+
+    /**
+     * @return X coordinate
+     */
+    public float x() {
+        return this.x;
+    }
+
+    /**
+     * @return Y coordinate
+     */
+    public float y() {
+        return this.y;
+    }
+
+    /**
+     * @return Z coordinate
+     */
+    public float z() {
+        return this.z;
+    }
+
+    /**
+     * @return W coordinate
+     */
+    public float w() {
+        return this.w;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object object) {
+        if (object == null || this.getClass() != object.getClass()) {
+            return false;
+        }
+
+        KVector4f kVector4f = (KVector4f) object;
+        return
+                Float.compare(x, kVector4f.x) == 0
+            &&  Float.compare(y, kVector4f.y) == 0
+            &&  Float.compare(z, kVector4f.z) == 0
+            &&  Float.compare(w, kVector4f.w) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y, z, w);
+    }
+
+    @Override
+    public String toString() {
+        return "KVector4f{" + "x=" + x + ", y=" + y + ", z=" + z + ", w=" + w + '}';
     }
 }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector4f.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector4f.java
@@ -19,7 +19,6 @@ package io.github.darthakiranihil.konna.core.struct;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector4f.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector4f.java
@@ -42,6 +42,15 @@ public final class KVector4f {
         this.w = w;
     }
 
+    private static int hash(float x, float y, float z, float w) {
+        int result = 1;
+        result = 31 * result + Float.floatToIntBits(x);
+        result = 33 * result + Float.floatToIntBits(y);
+        result = 37 * result + Float.floatToIntBits(z);
+        result = 41 * result + Float.floatToIntBits(w);
+        return result;
+    }
+
     // todo: soft references
     private static final Map<Integer, KVector4f> INSTANCES;
 
@@ -62,12 +71,15 @@ public final class KVector4f {
     }
 
     static KVector4f create(float x, float y, float z, float w) {
-        int hash = Objects.hash(x, y, z, w);
+        int hash = KVector4f.hash(x, y, z, w);
         if (!INSTANCES.containsKey(hash)) {
             INSTANCES.put(hash, new KVector4f(x, y, z, w));
         }
 
-        return INSTANCES.get(hash);
+        KVector4f instance = INSTANCES.get(hash);
+        return instance.x == x && instance.y == y && instance.z == z && instance.w == w
+            ? instance
+            : new KVector4f(x, y, z, w);
     }
 
     /**
@@ -99,26 +111,33 @@ public final class KVector4f {
     }
 
     @Override
-    public boolean equals(@Nullable Object object) {
+    public boolean equals(@Nullable final Object object) {
         if (object == null || this.getClass() != object.getClass()) {
             return false;
         }
 
         KVector4f kVector4f = (KVector4f) object;
         return
-                Float.compare(x, kVector4f.x) == 0
-            &&  Float.compare(y, kVector4f.y) == 0
-            &&  Float.compare(z, kVector4f.z) == 0
-            &&  Float.compare(w, kVector4f.w) == 0;
+                Float.compare(this.x, kVector4f.x) == 0
+            &&  Float.compare(this.y, kVector4f.y) == 0
+            &&  Float.compare(this.z, kVector4f.z) == 0
+            &&  Float.compare(this.w, kVector4f.w) == 0;
     }
 
+    // fixme: maybe this thing is not good, if needed - rework hash algorithm (as well as for other
+    //        vector types)
     @Override
     public int hashCode() {
-        return Objects.hash(x, y, z, w);
+        return KVector4f.hash(this.x, this.y, this.z, this.w);
     }
 
     @Override
     public String toString() {
-        return "KVector4f{" + "x=" + x + ", y=" + y + ", z=" + z + ", w=" + w + '}';
+        return
+                "KVector4f{"
+            +   "x=" + this.x
+            +   ", y=" + this.y
+            +   ", z=" + this.z
+            +   ", w=" + this.w + '}';
     }
 }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector4f.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVector4f.java
@@ -16,6 +16,10 @@
 
 package io.github.darthakiranihil.konna.core.struct;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Representation of a 4d vector, which coordinates are represented with floats.
  * @param x X coordinate
@@ -33,6 +37,9 @@ public record KVector4f(
     float w
 ) {
 
+    // todo: soft references
+    private static final Map<Integer, KVector4f> INSTANCES;
+
     /**
      * Zero vector - (0,0,0,0).
      */
@@ -42,4 +49,19 @@ public record KVector4f(
      */
     public static final KVector4f ONE = new KVector4f(1.0f, 1.0f, 1.0f, 1.0f);
 
+    static {
+        INSTANCES = new ConcurrentHashMap<>();
+
+        INSTANCES.put(ZERO.hashCode(), ZERO);
+        INSTANCES.put(ONE.hashCode(), ONE);
+    }
+
+    static KVector4f create(float x, float y, float z, float w) {
+        int hash = Objects.hash(x, y, z, w);
+        if (!INSTANCES.containsKey(hash)) {
+            INSTANCES.put(hash, new KVector4f(x, y, z, w));
+        }
+
+        return INSTANCES.get(hash);
+    }
 }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVectors.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVectors.java
@@ -18,20 +18,70 @@ package io.github.darthakiranihil.konna.core.struct;
 
 import io.github.darthakiranihil.konna.core.object.KUninstantiable;
 
+/**
+ * Factory class for creating vector objects.
+ *
+ * @since 0.7.0
+ * @author Darth Akira Nihil
+ */
 public final class KVectors extends KUninstantiable {
 
     private KVectors() {
         super();
     }
 
+    /**
+     * <p>
+     *     Creates a new 2D-int vector with specified coordinates.
+     * </p>
+     * <p>
+     *     If there is a vector
+     *     with those coordinates that is already allocated, the reference to it
+     *     will be returned instead of creating a new one.
+     * </p>
+     *
+     * @param x X coordinate of vector
+     * @param y Y coordinate of vector
+     * @return An instance of vector with specified coordinates
+     */
     public static KVector2i new2i(int x, int y) {
         return KVector2i.create(x, y);
     }
 
+    /**
+     * <p>
+     *     Creates a new 2D-float vector with specified coordinates.
+     * </p>
+     * <p>
+     *     If there is a vector
+     *     with those coordinates that is already allocated, the reference to it
+     *     will be returned instead of creating a new one.
+     * </p>
+     *
+     * @param x X coordinate of vector
+     * @param y Y coordinate of vector
+     * @return An instance of vector with specified coordinates
+     */
     public static KVector2f new2f(float x, float y) {
         return KVector2f.create(x, y);
     }
 
+    /**
+     * <p>
+     *     Creates a new 4D-float vector with specified coordinates.
+     * </p>
+     * <p>
+     *     If there is a vector
+     *     with those coordinates that is already allocated, the reference to it
+     *     will be returned instead of creating a new one.
+     * </p>
+     *
+     * @param x X coordinate of vector
+     * @param y Y coordinate of vector
+     * @param z Z coordinate of vector
+     * @param w W coordinate of vector
+     * @return An instance of vector with specified coordinates
+     */
     public static KVector4f new4f(float x, float y, float z, float w) {
         return KVector4f.create(x, y, z, w);
     }

--- a/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVectors.java
+++ b/core/src/main/java/io/github/darthakiranihil/konna/core/struct/KVectors.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.darthakiranihil.konna.core.struct;
+
+import io.github.darthakiranihil.konna.core.object.KUninstantiable;
+
+public final class KVectors extends KUninstantiable {
+
+    private KVectors() {
+        super();
+    }
+
+    public static KVector2i new2i(int x, int y) {
+        return KVector2i.create(x, y);
+    }
+
+    public static KVector2f new2f(float x, float y) {
+        return KVector2f.create(x, y);
+    }
+
+    public static KVector4f new4f(float x, float y, float z, float w) {
+        return KVector4f.create(x, y, z, w);
+    }
+
+}

--- a/core/src/test/java/io/github/darthakiranihil/konna/core/struct/KVector2fTests.java
+++ b/core/src/test/java/io/github/darthakiranihil/konna/core/struct/KVector2fTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.darthakiranihil.konna.core.struct;
+
+import io.github.darthakiranihil.konna.test.KStandardTestClass;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class KVector2fTests extends KStandardTestClass {
+
+    @Test
+    public void testCreateNonStatic() {
+
+        KVector2f a = KVector2f.create(1.0f, 2.0f);
+        KVector2f b = KVector2f.create(1.0f, 2.0f);
+
+        Assertions.assertSame(a, b);
+        Assertions.assertEquals(a, b);
+
+        Assertions.assertEquals(a.x(), b.x());
+        Assertions.assertEquals(a.y(), b.y());
+
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertEquals(a.toString(), b.toString());
+
+    }
+
+    @Test
+    public void testCreateStatic() {
+        KVector2f zero = KVector2f.create(0.0f, 0.0f);
+        KVector2f one = KVector2f.create(1.0f, 1.0f);
+
+        Assertions.assertSame(KVector2f.ZERO, zero);
+        Assertions.assertSame(KVector2f.ONE, one);
+        Assertions.assertEquals(KVector2f.ZERO, zero);
+        Assertions.assertEquals(KVector2f.ONE, one);
+
+        Assertions.assertEquals(KVector2f.ZERO.x(), zero.x());
+        Assertions.assertEquals(KVector2f.ZERO.y(), zero.y());
+
+        Assertions.assertEquals(KVector2f.ONE.x(), one.x());
+        Assertions.assertEquals(KVector2f.ONE.y(), one.y());
+
+        Assertions.assertEquals(KVector2f.ZERO.hashCode(), zero.hashCode());
+        Assertions.assertEquals(KVector2f.ZERO.hashCode(), zero.hashCode());
+        Assertions.assertEquals(KVector2f.ONE.toString(), one.toString());
+        Assertions.assertEquals(KVector2f.ONE.toString(), one.toString());
+    }
+
+    @SuppressWarnings("MisorderedAssertEqualsArguments")
+    @Test
+    public void testEquals() {
+
+        KVector2f a = KVector2f.create(1.0f, 2.0f);
+
+        KVector2f dx = KVector2f.create(2.0f, 2.0f);
+        KVector2f dy = KVector2f.create(1.0f, 3.0f);
+        KVector2f same = KVector2f.create(1.0f, 2.0f);
+
+        Assertions.assertNotEquals(a, null);
+        Assertions.assertNotEquals(a, 1);
+        Assertions.assertNotEquals(a, dx);
+        Assertions.assertNotEquals(a, dy);
+        Assertions.assertEquals(a, same);
+
+    }
+
+}

--- a/core/src/test/java/io/github/darthakiranihil/konna/core/struct/KVector2iTests.java
+++ b/core/src/test/java/io/github/darthakiranihil/konna/core/struct/KVector2iTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.darthakiranihil.konna.core.struct;
+
+import io.github.darthakiranihil.konna.test.KStandardTestClass;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class KVector2iTests extends KStandardTestClass {
+
+    @Test
+    public void testCreateNonStatic() {
+
+        KVector2i a = KVector2i.create(1, 2);
+        KVector2i b = KVector2i.create(1, 2);
+
+        Assertions.assertSame(a, b);
+        Assertions.assertEquals(a, b);
+
+        Assertions.assertEquals(a.x(), b.x());
+        Assertions.assertEquals(a.y(), b.y());
+
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertEquals(a.toString(), b.toString());
+
+    }
+
+    @Test
+    public void testCreateStatic() {
+        KVector2i zero = KVector2i.create(0, 0);
+        KVector2i one = KVector2i.create(1, 1);
+
+        Assertions.assertSame(KVector2i.ZERO, zero);
+        Assertions.assertSame(KVector2i.ONE, one);
+        Assertions.assertEquals(KVector2i.ZERO, zero);
+        Assertions.assertEquals(KVector2i.ONE, one);
+
+        Assertions.assertEquals(KVector2i.ZERO.x(), zero.x());
+        Assertions.assertEquals(KVector2i.ZERO.y(), zero.y());
+
+        Assertions.assertEquals(KVector2i.ONE.x(), one.x());
+        Assertions.assertEquals(KVector2i.ONE.y(), one.y());
+
+        Assertions.assertEquals(KVector2i.ZERO.hashCode(), zero.hashCode());
+        Assertions.assertEquals(KVector2i.ZERO.hashCode(), zero.hashCode());
+        Assertions.assertEquals(KVector2i.ONE.toString(), one.toString());
+        Assertions.assertEquals(KVector2i.ONE.toString(), one.toString());
+    }
+
+    @SuppressWarnings("MisorderedAssertEqualsArguments")
+    @Test
+    public void testEquals() {
+
+        KVector2i a = KVector2i.create(1, 2);
+
+        KVector2i dx = KVector2i.create(2, 2);
+        KVector2i dy = KVector2i.create(1, 3);
+        KVector2i same = KVector2i.create(1, 2);
+
+        Assertions.assertNotEquals(a, null);
+        Assertions.assertNotEquals(a, 1);
+        Assertions.assertNotEquals(a, dx);
+        Assertions.assertNotEquals(a, dy);
+        Assertions.assertEquals(a, same);
+
+    }
+
+    @Test
+    public void testMaths() {
+
+        KVector2i a = KVector2i.create(1, 2);
+        KVector2i b = KVector2i.create(3, 4);
+
+        KVector2i sum = a.add(b);
+        KVector2i diff = a.subtract(b);
+        KVector2i neg = a.negate();
+
+        KVector2i sumCheck = KVector2i.create(4, 6);
+        KVector2i diffCheck = KVector2i.create(-2, -2);
+        KVector2i negCheck = KVector2i.create(-1, -2);
+
+        Assertions.assertEquals(sumCheck, sum);
+        Assertions.assertEquals(diffCheck, diff);
+        Assertions.assertEquals(negCheck, neg);
+
+        Assertions.assertSame(sumCheck, sum);
+        Assertions.assertSame(diffCheck, diff);
+        Assertions.assertSame(negCheck, neg);
+
+    }
+}

--- a/core/src/test/java/io/github/darthakiranihil/konna/core/struct/KVector4fTests.java
+++ b/core/src/test/java/io/github/darthakiranihil/konna/core/struct/KVector4fTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.darthakiranihil.konna.core.struct;
+
+import io.github.darthakiranihil.konna.test.KStandardTestClass;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class KVector4fTests extends KStandardTestClass {
+
+    @Test
+    public void testCreateNonStatic() {
+
+        KVector4f a = KVector4f.create(1.0f, 2.0f, 3.0f, 4.0f);
+        KVector4f b = KVector4f.create(1.0f, 2.0f, 3.0f, 4.0f);
+
+        Assertions.assertSame(a, b);
+        Assertions.assertEquals(a, b);
+
+        Assertions.assertEquals(a.x(), b.x());
+        Assertions.assertEquals(a.y(), b.y());
+        Assertions.assertEquals(a.z(), b.z());
+        Assertions.assertEquals(a.w(), b.w());
+
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertEquals(a.toString(), b.toString());
+
+    }
+
+    @Test
+    public void testCreateStatic() {
+        KVector4f zero = KVector4f.create(0.0f, 0.0f, 0.0f, 0.0f);
+        KVector4f one = KVector4f.create(1.0f, 1.0f, 1.0f, 1.0f);
+
+        Assertions.assertSame(KVector4f.ZERO, zero);
+        Assertions.assertSame(KVector4f.ONE, one);
+        Assertions.assertEquals(KVector4f.ZERO, zero);
+        Assertions.assertEquals(KVector4f.ONE, one);
+
+        Assertions.assertEquals(KVector4f.ZERO.x(), zero.x());
+        Assertions.assertEquals(KVector4f.ZERO.y(), zero.y());
+        Assertions.assertEquals(KVector4f.ZERO.z(), zero.z());
+        Assertions.assertEquals(KVector4f.ZERO.w(), zero.w());
+
+        Assertions.assertEquals(KVector4f.ONE.x(), one.x());
+        Assertions.assertEquals(KVector4f.ONE.y(), one.y());
+        Assertions.assertEquals(KVector4f.ONE.z(), one.z());
+        Assertions.assertEquals(KVector4f.ONE.w(), one.w());
+
+        Assertions.assertEquals(KVector4f.ZERO.hashCode(), zero.hashCode());
+        Assertions.assertEquals(KVector4f.ZERO.hashCode(), zero.hashCode());
+        Assertions.assertEquals(KVector4f.ONE.toString(), one.toString());
+        Assertions.assertEquals(KVector4f.ONE.toString(), one.toString());
+    }
+
+    @SuppressWarnings("MisorderedAssertEqualsArguments")
+    @Test
+    public void testEquals() {
+
+        KVector4f a = KVector4f.create(1.0f, 2.0f, 3.0f, 4.0f);
+
+        KVector4f dx = KVector4f.create(2.0f, 2.0f, 3.0f, 4.0f);
+        KVector4f dy = KVector4f.create(1.0f, 3.0f, 3.0f, 4.0f);
+        KVector4f dz = KVector4f.create(1.0f, 2.0f, 4.0f, 4.0f);
+        KVector4f dw = KVector4f.create(1.0f, 2.0f, 3.0f, 5.0f);
+        KVector4f same = KVector4f.create(1.0f, 2.0f, 3.0f, 4.0f);
+
+        Assertions.assertNotEquals(a, null);
+        Assertions.assertNotEquals(a, 1);
+        Assertions.assertNotEquals(a, dx);
+        Assertions.assertNotEquals(a, dy);
+        Assertions.assertNotEquals(a, dz);
+        Assertions.assertNotEquals(a, dw);
+        Assertions.assertEquals(a, same);
+
+    }
+}

--- a/implementations/implementations-opengl33/src/main/java/io/github/darthakiranihil/konna/graphics/opengl33/KGeometryUtils.java
+++ b/implementations/implementations-opengl33/src/main/java/io/github/darthakiranihil/konna/graphics/opengl33/KGeometryUtils.java
@@ -60,9 +60,9 @@ final class KGeometryUtils extends KUninstantiable {
             var second = triangle.points[1];
             var third = triangle.points[2];
 
-            indices[i] = idxMap.get(new KVector2i((int) first.getX(), (int) first.getY()));
-            indices[i + 1] = idxMap.get(new KVector2i((int) second.getX(), (int) second.getY()));
-            indices[i + 2] = idxMap.get(new KVector2i((int) third.getX(), (int) third.getY()));
+            indices[i] = idxMap.get(KVectors.new2i((int) first.getX(), (int) first.getY()));
+            indices[i + 1] = idxMap.get(KVectors.new2i((int) second.getX(), (int) second.getY()));
+            indices[i + 2] = idxMap.get(KVectors.new2i((int) third.getX(), (int) third.getY()));
 
             i += 3;
         }
@@ -94,7 +94,7 @@ final class KGeometryUtils extends KUninstantiable {
         final KSize viewportSize
     ) {
 
-        KVector2i pos = new KVector2i(
+        KVector2i pos = KVectors.new2i(
             viewportSize.width() / 2 + v.x(),
             viewportSize.height() / 2 + v.y()
         );

--- a/implementations/implementations-opengl33/src/main/java/io/github/darthakiranihil/konna/graphics/opengl33/KGeometryUtils.java
+++ b/implementations/implementations-opengl33/src/main/java/io/github/darthakiranihil/konna/graphics/opengl33/KGeometryUtils.java
@@ -20,6 +20,7 @@ import io.github.darthakiranihil.konna.core.object.KUninstantiable;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KExcludeFromGeneratedCoverageReport;
 import org.jetbrains.annotations.ApiStatus;
 import org.poly2tri.Poly2Tri;
@@ -79,7 +80,7 @@ final class KGeometryUtils extends KUninstantiable {
         float x = 2.0f * ((float) v.x() / viewportSize.width()) - 1.0f;
         float y = -2.0f * ((float) v.y() / viewportSize.height()) + 1.0f;
 
-        return new KVector2f(x, y);
+        return KVectors.new2f(x, y);
     }
 
     /**
@@ -101,7 +102,7 @@ final class KGeometryUtils extends KUninstantiable {
         float x = 2.0f * ((float) pos.x() / viewportSize.width()) - 1.0f;
         float y = -2.0f * ((float) pos.y() / viewportSize.height()) + 1.0f;
 
-        return new KVector2f(x, y);
+        return KVectors.new2f(x, y);
     }
 
 }

--- a/implementations/implementations-opengl33/src/test/java/io/github/darthakiranihil/konna/graphics/opengl33/KGl33TransformMatrixCalculatorPositiveTests.java
+++ b/implementations/implementations-opengl33/src/test/java/io/github/darthakiranihil/konna/graphics/opengl33/KGl33TransformMatrixCalculatorPositiveTests.java
@@ -55,7 +55,7 @@ public class KGl33TransformMatrixCalculatorPositiveTests {
 
         KTransform transform = new KTransform();
 
-        KVector2i vector = new KVector2i(320, 320);
+        KVector2i vector = KVectors.new2i(320, 320);
         transform.translate(vector);
 
         KVector2i translation = transform.getTranslation();
@@ -110,7 +110,7 @@ public class KGl33TransformMatrixCalculatorPositiveTests {
         KTransform transform = new KTransform();
 
         double angle = Math.PI / 6;
-        KVector2i vector = new KVector2i(320, 320);
+        KVector2i vector = KVectors.new2i(320, 320);
         KVector2f scale = KVectors.new2f(2.0f, 2.0f);
 
         transform

--- a/implementations/implementations-opengl33/src/test/java/io/github/darthakiranihil/konna/graphics/opengl33/KGl33TransformMatrixCalculatorPositiveTests.java
+++ b/implementations/implementations-opengl33/src/test/java/io/github/darthakiranihil/konna/graphics/opengl33/KGl33TransformMatrixCalculatorPositiveTests.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.graphics.opengl33;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.graphics.KTransform;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -72,7 +73,7 @@ public class KGl33TransformMatrixCalculatorPositiveTests {
 
         KTransform transform = new KTransform();
 
-        KVector2f scale = new KVector2f(2.0f, 2.0f);
+        KVector2f scale = KVectors.new2f(2.0f, 2.0f);
         transform.scale(scale);
 
         KVector2f scaling = transform.getScaling();
@@ -90,7 +91,7 @@ public class KGl33TransformMatrixCalculatorPositiveTests {
 
         KTransform transform = new KTransform();
 
-        KVector2f scale = new KVector2f(2.0f, 2.0f);
+        KVector2f scale = KVectors.new2f(2.0f, 2.0f);
         transform.setScaling(scale);
 
         KVector2f scaling = transform.getScaling();
@@ -110,7 +111,7 @@ public class KGl33TransformMatrixCalculatorPositiveTests {
 
         double angle = Math.PI / 6;
         KVector2i vector = new KVector2i(320, 320);
-        KVector2f scale = new KVector2f(2.0f, 2.0f);
+        KVector2f scale = KVectors.new2f(2.0f, 2.0f);
 
         transform
             .rotate(angle)

--- a/implementations/implementations-stb/src/test/java/io/github/darthakiranihil/konna/graphics/stb/KStbImagePositiveTests.java
+++ b/implementations/implementations-stb/src/test/java/io/github/darthakiranihil/konna/graphics/stb/KStbImagePositiveTests.java
@@ -21,6 +21,7 @@ import io.github.darthakiranihil.konna.core.io.KStandardResourceLoader;
 import io.github.darthakiranihil.konna.core.io.protocol.KClasspathProtocol;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import io.github.darthakiranihil.konna.graphics.KColor;
 import io.github.darthakiranihil.konna.graphics.image.KImage;
@@ -53,13 +54,13 @@ public class KStbImagePositiveTests extends KStandardTestClass {
 
         for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 4; j++) {
-                Assertions.assertEquals(KColor.RED, image.getPixelColor(new KVector2i(i, j)));
+                Assertions.assertEquals(KColor.RED, image.getPixelColor(KVectors.new2i(i, j)));
             }
         }
 
         for (int i = 4; i < 7; i++) {
             for (int j = 0; j < 4; j++) {
-                Assertions.assertEquals(KColor.GREEN, image.getPixelColor(new KVector2i(i, j)));
+                Assertions.assertEquals(KColor.GREEN, image.getPixelColor(KVectors.new2i(i, j)));
             }
         }
 
@@ -80,16 +81,16 @@ public class KStbImagePositiveTests extends KStandardTestClass {
         Assertions.assertEquals(4, slice.height());
         for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 4; j++) {
-                Assertions.assertEquals(KColor.RED, slice.getPixelColor(new KVector2i(i, j)));
+                Assertions.assertEquals(KColor.RED, slice.getPixelColor(KVectors.new2i(i, j)));
             }
         }
 
-        KImage slice2 = image.slice(new KVector2i(4, 4), KSize.squared(4));
+        KImage slice2 = image.slice(KVectors.new2i(4, 4), KSize.squared(4));
         Assertions.assertEquals(4, slice2.width());
         Assertions.assertEquals(4, slice2.height());
         for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 4; j++) {
-                Assertions.assertEquals(KColor.WHITE, slice2.getPixelColor(new KVector2i(i, j)));
+                Assertions.assertEquals(KColor.WHITE, slice2.getPixelColor(KVectors.new2i(i, j)));
             }
         }
 

--- a/implementations/implementations-std-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/text/KSquaredAsciiTiledFontFormat.java
+++ b/implementations/implementations-std-graphics/src/main/java/io/github/darthakiranihil/konna/graphics/text/KSquaredAsciiTiledFontFormat.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.graphics.text;
 import io.github.darthakiranihil.konna.core.object.KObject;
 import io.github.darthakiranihil.konna.core.di.KSingleton;
 import io.github.darthakiranihil.konna.core.struct.KVector2f;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 
 /**
  * Implementation of {@link KTiledFontFormat} representing a 16x16 characters
@@ -44,10 +45,10 @@ public class KSquaredAsciiTiledFontFormat extends KObject implements KTiledFontF
             int col = i % FACE_SHEET_SIDE;
             this.generatedGlyphs[row][col] = new KTiledFontGlyph(
                 new KVector2f[]{
-                    new KVector2f(UV_WIDTH * col, UV_WIDTH * row),
-                    new KVector2f(UV_WIDTH * (col + 1), UV_WIDTH * row),
-                    new KVector2f(UV_WIDTH * (col + 1), UV_WIDTH * (row + 1)),
-                    new KVector2f(UV_WIDTH * col, UV_WIDTH * (row + 1)),
+                    KVectors.new2f(UV_WIDTH * col, UV_WIDTH * row),
+                    KVectors.new2f(UV_WIDTH * (col + 1), UV_WIDTH * row),
+                    KVectors.new2f(UV_WIDTH * (col + 1), UV_WIDTH * (row + 1)),
+                    KVectors.new2f(UV_WIDTH * col, UV_WIDTH * (row + 1)),
                 }
             );
         }

--- a/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/KRaycastLevelObserver.java
+++ b/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/KRaycastLevelObserver.java
@@ -16,10 +16,7 @@
 
 package io.github.darthakiranihil.konna.level;
 
-import io.github.darthakiranihil.konna.core.struct.KPair;
-import io.github.darthakiranihil.konna.core.struct.KTriplet;
-import io.github.darthakiranihil.konna.core.struct.KVector2f;
-import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.*;
 
 import java.util.*;
 
@@ -77,7 +74,7 @@ public final class KRaycastLevelObserver implements KLevelObserver {
                 new KTriplet<>(
                     sector,
                     visionRange * 2,
-                    new KVector2f(x + 0.5f, y + 0.5f)
+                    KVectors.new2f(x + 0.5f, y + 0.5f)
                 )
             );
 
@@ -122,7 +119,7 @@ public final class KRaycastLevelObserver implements KLevelObserver {
                             new KTriplet<>(
                                 linkData.linkedSector().name(),
                                 vision,
-                                new KVector2f(
+                                KVectors.new2f(
                                     linkData.destination().x(),
                                     linkData.destination().y()
                                 )

--- a/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/generator/constant/KVector2iConstantNode.java
+++ b/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/generator/constant/KVector2iConstantNode.java
@@ -20,6 +20,7 @@ import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.except.KInvalidArgumentException;
 import io.github.darthakiranihil.konna.core.io.KAssetDefinition;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.generator.KConstantNode;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeOutputParam;
 
@@ -52,9 +53,9 @@ public final class KVector2iConstantNode implements KConstantNode {
             );
         }
 
-        this.object = new KVector2i(
+        this.object = KVectors.new2i(
             data.getInt("x"),
-            data.getInt("y")
+                                     data.getInt("y")
         );
     }
 

--- a/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/generator/maker/KRandomPointOnPassabilityLayerNode.java
+++ b/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/generator/maker/KRandomPointOnPassabilityLayerNode.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.generator.maker;
 
 import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNode;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeInputParam;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeOutputParam;
@@ -52,7 +53,7 @@ public final class KRandomPointOnPassabilityLayerNode implements KGeneratorNode 
         KUniversalMap result = new KUniversalMap();
         result.put(
             "point",
-            new KVector2i(
+            KVectors.new2i(
                 rnd.nextInt(0, layer.getSize().width()),
                 rnd.nextInt(0, layer.getSize().height())
             )

--- a/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/generator/maker/partition/KBspNode.java
+++ b/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/generator/maker/partition/KBspNode.java
@@ -20,6 +20,7 @@ import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.struct.KPair;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNode;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeInputParam;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeOutputParam;
@@ -182,7 +183,7 @@ public final class KBspNode implements KGeneratorNode {
 
             var first = new KPair<>(topLeft, new KSize(splitPoint, size.height()));
             var second = new KPair<>(
-                topLeft.add(new KVector2i(splitPoint, 0)),
+                topLeft.add(KVectors.new2i(splitPoint, 0)),
                 new KSize(
                 size.width() - splitPoint,
                     size.height()
@@ -202,7 +203,7 @@ public final class KBspNode implements KGeneratorNode {
 
             var first = new KPair<>(topLeft, new KSize(size.width(), splitPoint));
             var second = new KPair<>(
-                topLeft.add(new KVector2i(0, splitPoint)),
+                topLeft.add(KVectors.new2i(0, splitPoint)),
                 new KSize(
                     size.width(),
                     size.height() - splitPoint

--- a/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KRandomRectangularCenteredRoomsInPartitionNode.java
+++ b/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KRandomRectangularCenteredRoomsInPartitionNode.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.level.generator.maker.passability;
 import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNode;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeInputParam;
 import io.github.darthakiranihil.konna.level.generator.KGeneratorNodeOutputParam;
@@ -94,12 +95,12 @@ public final class KRandomRectangularCenteredRoomsInPartitionNode implements KGe
 
                 KSize diggingBoxSize = size.reduce(2, 2);
 
-                KVector2i newTopLeft = new KVector2i(
+                KVector2i newTopLeft = KVectors.new2i(
                     rnd.nextInt(topLeft.x(), center.x() + 1),
                     rnd.nextInt(topLeft.y(), center.y() + 1)
                 );
 
-                KVector2i newBottomRight = new KVector2i(
+                KVector2i newBottomRight = KVectors.new2i(
                     rnd.nextInt(center.x(), bottomRight.x() + 1),
                     rnd.nextInt(center.y(), bottomRight.y() + 1)
                 );

--- a/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KPassabilityLayer.java
+++ b/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/layer/KPassabilityLayer.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.level.layer;
 import io.github.darthakiranihil.konna.core.except.KInvalidArgumentException;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.layer.tool.KPassabilityLayerTool;
 import org.jspecify.annotations.Nullable;
 
@@ -206,13 +207,13 @@ public final class KPassabilityLayer
                 return KVector2i.MINUS_ONE;
             }
 
-            KVector2i position = new KVector2i(
+            KVector2i position = KVectors.new2i(
                 rnd.nextInt(0, this.self.size.width()),
                 rnd.nextInt(0, this.self.size.height())
             );
 
             while (this.getOnPosition(position) != KPassabilityState.PASSABLE) {
-                position = new KVector2i(
+                position = KVectors.new2i(
                     rnd.nextInt(0, this.self.size.width()),
                     rnd.nextInt(0, this.self.size.height())
                 );
@@ -357,7 +358,7 @@ public final class KPassabilityLayer
 
                 KPassabilityState state = this.states[j][i];
                 if (state == KPassabilityState.PASSABLE && this.areas[j][i] == 0) {
-                    return new KVector2i(i, j);
+                    return KVectors.new2i(i, j);
                 }
 
             }
@@ -374,7 +375,7 @@ public final class KPassabilityLayer
     ) {
 
         KPassabilityState state = this.getOnPosition(x, y);
-        KVector2i pos = new KVector2i(x, y);
+        KVector2i pos = KVectors.new2i(x, y);
         if (
                 state == KPassabilityState.PASSABLE
             &&  this.areas[y][x] == 0

--- a/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/path/KAStarPathfinder.java
+++ b/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/path/KAStarPathfinder.java
@@ -16,10 +16,7 @@
 
 package io.github.darthakiranihil.konna.level.path;
 
-import io.github.darthakiranihil.konna.core.struct.KPair;
-import io.github.darthakiranihil.konna.core.struct.KSize;
-import io.github.darthakiranihil.konna.core.struct.KTriplet;
-import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.*;
 import io.github.darthakiranihil.konna.core.struct.graph.KIntWeightedGraph;
 import io.github.darthakiranihil.konna.level.KTileInfo;
 import io.github.darthakiranihil.konna.level.KLevel;
@@ -274,7 +271,7 @@ public class KAStarPathfinder implements KPathfinder {
         AStarNode[][] pathGraph = new AStarNode[sectorSize.height()][sectorSize.width()];
         for (int i = 0; i < sectorSize.height(); i++) {
             for (int j = 0; j < sectorSize.width(); j++) {
-                pathGraph[i][j] = new AStarNode(new KVector2i(j, i));
+                pathGraph[i][j] = new AStarNode(KVectors.new2i(j, i));
             }
         }
         pathGraph[srcY][srcX].w = 0;
@@ -282,7 +279,7 @@ public class KAStarPathfinder implements KPathfinder {
         Queue<KVector2i> reachable = new LinkedList<>();
         Set<KVector2i> explored = new HashSet<>();
 
-        reachable.add(new KVector2i(srcX, srcY));
+        reachable.add(KVectors.new2i(srcX, srcY));
 
         while (!reachable.isEmpty()) {
             KVector2i node = this.chooseNode(reachable, pathGraph, dstX, dstY);
@@ -364,7 +361,7 @@ public class KAStarPathfinder implements KPathfinder {
         while (goal.previous != null) {
             KVector2i prevPosition = goal.previous.position;
             path.addFirst(
-                new KVector2i(
+                KVectors.new2i(
                     goal.position.x() - prevPosition.x(),
                     goal.position.y() - prevPosition.y()
                 )
@@ -449,7 +446,7 @@ public class KAStarPathfinder implements KPathfinder {
             var firstLinkTool = first.getTool(KSectorLinkLayerTool.class);
             var secondLinkTool = second.getTool(KSectorLinkLayerTool.class);
 
-            KVector2i source = i == 0 ? new KVector2i(srcX, srcY) : checkpoints.getLast().third();
+            KVector2i source = i == 0 ? KVectors.new2i(srcX, srcY) : checkpoints.getLast().third();
 
             var linksFromFirstToSecond = firstLinkTool.getToSector(secondSectorName);
             var linksFromSecondToThird = secondLinkTool.getToSector(thirdSectorName);
@@ -501,14 +498,14 @@ public class KAStarPathfinder implements KPathfinder {
         KLevelSector last = location.getSector(lastSectorName);
 
         KVector2i source = checkpoints.isEmpty()
-            ? new KVector2i(srcX, srcY)
+            ? KVectors.new2i(srcX, srcY)
             : checkpoints.getLast().third();
 
         var penultimateLinkTool = penultimate.getTool(KSectorLinkLayerTool.class);
         var linksFromPenultimateToLast = penultimateLinkTool.getToSector(lastSectorName);
 
         List<KVector2i> goodLinks = new ArrayList<>(linksFromPenultimateToLast.size());
-        KVector2i destination = new KVector2i(dstX, dstY);
+        KVector2i destination = KVectors.new2i(dstX, dstY);
 
         for (var linkFromPenultimateToLast: linksFromPenultimateToLast.entrySet()) {
             var lastReachabilityTool = last.getTool(KReachabilityAreaLayerTool.class);

--- a/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/struct/KPartition.java
+++ b/implementations/implementations-std-level/src/main/java/io/github/darthakiranihil/konna/level/struct/KPartition.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.struct;
 
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 
 import java.util.Collections;
 import java.util.List;
@@ -53,11 +54,11 @@ public final class KPartition {
         this.topLeft = topLeft;
         this.size = size;
         this.subpartitions = Collections.unmodifiableList(subpartitions);
-        this.center = new KVector2i(
+        this.center = KVectors.new2i(
             topLeft.x() + (int) (size.width() / 2.0f),
             topLeft.y() + (int) (size.height() / 2.0f)
         );
-        this.bottomRight = new KVector2i(
+        this.bottomRight = KVectors.new2i(
             topLeft.x() + size.width(),
             topLeft.y() + size.height()
         );

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KRaycastLevelObserverPositiveTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KRaycastLevelObserverPositiveTests.java
@@ -21,6 +21,7 @@ import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KStandardEventSystem;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.entity.KStaticEntity;
 import io.github.darthakiranihil.konna.level.layer.*;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
@@ -63,8 +64,8 @@ public class KRaycastLevelObserverPositiveTests extends KStandardTestClass {
 
         KLevel level = new KLevel("loc1", List.of(sector));
 
-        KFov fov = observer.observePointBlindly(level,"sector_1", new KVector2i(5, 5), 3);
-        KFov fov2 = observer.observePoint(level, "sector_1", new KVector2i(5, 5), 3);
+        KFov fov = observer.observePointBlindly(level,"sector_1", KVectors.new2i(5, 5), 3);
+        KFov fov2 = observer.observePoint(level, "sector_1", KVectors.new2i(5, 5), 3);
         Assertions.assertEquals(21, fov.getObservedSlices().size());
         Assertions.assertEquals(fov.getObservedSlices().size(), fov2.getObservedSlices().size());
         Assertions.assertEquals(1, fov.getEntitiesWithDescriptor("ste").size());
@@ -72,27 +73,27 @@ public class KRaycastLevelObserverPositiveTests extends KStandardTestClass {
         Assertions.assertTrue(
             positions.containsAll(
                 List.of(
-                    new KVector2i(3, 4),
-                    new KVector2i(3, 5),
-                    new KVector2i(3, 6),
-                    new KVector2i(4, 3),
-                    new KVector2i(4, 4),
-                    new KVector2i(4, 5),
-                    new KVector2i(4, 6),
-                    new KVector2i(4, 7),
-                    new KVector2i(5, 3),
-                    new KVector2i(5, 4),
-                    new KVector2i(5, 5),
-                    new KVector2i(5, 6),
-                    new KVector2i(5, 7),
-                    new KVector2i(6, 3),
-                    new KVector2i(6, 4),
-                    new KVector2i(6, 5),
-                    new KVector2i(6, 6),
-                    new KVector2i(6, 7),
-                    new KVector2i(7, 4),
-                    new KVector2i(7, 5),
-                    new KVector2i(7, 6)
+                    KVectors.new2i(3, 4),
+                    KVectors.new2i(3, 5),
+                    KVectors.new2i(3, 6),
+                    KVectors.new2i(4, 3),
+                    KVectors.new2i(4, 4),
+                    KVectors.new2i(4, 5),
+                    KVectors.new2i(4, 6),
+                    KVectors.new2i(4, 7),
+                    KVectors.new2i(5, 3),
+                    KVectors.new2i(5, 4),
+                    KVectors.new2i(5, 5),
+                    KVectors.new2i(5, 6),
+                    KVectors.new2i(5, 7),
+                    KVectors.new2i(6, 3),
+                    KVectors.new2i(6, 4),
+                    KVectors.new2i(6, 5),
+                    KVectors.new2i(6, 6),
+                    KVectors.new2i(6, 7),
+                    KVectors.new2i(7, 4),
+                    KVectors.new2i(7, 5),
+                    KVectors.new2i(7, 6)
                 )
             )
         );
@@ -149,32 +150,32 @@ public class KRaycastLevelObserverPositiveTests extends KStandardTestClass {
         Assertions.assertTrue(
             positions.containsAll(
                 List.of(
-                    new KVector2i(0, 6),
-                    new KVector2i(10, 7),
-                    new KVector2i(9, 3),
-                    new KVector2i(10, 3),
-                    new KVector2i(8, 4),
-                    new KVector2i(2, 6),
-                    new KVector2i(8, 5),
-                    new KVector2i(9, 5),
-                    new KVector2i(10, 4),
-                    new KVector2i(10, 5),
-                    new KVector2i(0, 4),
-                    new KVector2i(8, 3),
-                    new KVector2i(8, 6),
-                    new KVector2i(2, 5),
-                    new KVector2i(9, 4),
-                    new KVector2i(1, 4),
-                    new KVector2i(1, 3),
-                    new KVector2i(2, 4),
-                    new KVector2i(10, 6),
-                    new KVector2i(0, 3),
-                    new KVector2i(0, 7),
-                    new KVector2i(1, 5),
-                    new KVector2i(1, 7),
-                    new KVector2i(1, 6),
-                    new KVector2i(9, 6),
-                    new KVector2i(0, 5)
+                    KVectors.new2i(0, 6),
+                    KVectors.new2i(10, 7),
+                    KVectors.new2i(9, 3),
+                    KVectors.new2i(10, 3),
+                    KVectors.new2i(8, 4),
+                    KVectors.new2i(2, 6),
+                    KVectors.new2i(8, 5),
+                    KVectors.new2i(9, 5),
+                    KVectors.new2i(10, 4),
+                    KVectors.new2i(10, 5),
+                    KVectors.new2i(0, 4),
+                    KVectors.new2i(8, 3),
+                    KVectors.new2i(8, 6),
+                    KVectors.new2i(2, 5),
+                    KVectors.new2i(9, 4),
+                    KVectors.new2i(1, 4),
+                    KVectors.new2i(1, 3),
+                    KVectors.new2i(2, 4),
+                    KVectors.new2i(10, 6),
+                    KVectors.new2i(0, 3),
+                    KVectors.new2i(0, 7),
+                    KVectors.new2i(1, 5),
+                    KVectors.new2i(1, 7),
+                    KVectors.new2i(1, 6),
+                    KVectors.new2i(9, 6),
+                    KVectors.new2i(0, 5)
                 )
             )
         );
@@ -222,38 +223,38 @@ public class KRaycastLevelObserverPositiveTests extends KStandardTestClass {
         Assertions.assertTrue(
             positions.containsAll(
                 List.of(
-                    new KVector2i(7, 5),
-                    new KVector2i(7, 6),
-                    new KVector2i(6, 6),
-                    new KVector2i(4, 5),
-                    new KVector2i(6, 7),
-                    new KVector2i(6, 8),
-                    new KVector2i(4, 6),
-                    new KVector2i(6, 9),
-                    new KVector2i(4, 7),
-                    new KVector2i(6, 10),
-                    new KVector2i(4, 8),
-                    new KVector2i(2, 6),
-                    new KVector2i(4, 9),
-                    new KVector2i(2, 7),
-                    new KVector2i(4, 10),
-                    new KVector2i(8, 6),
-                    new KVector2i(6, 5),
-                    new KVector2i(8, 7),
-                    new KVector2i(5, 5),
-                    new KVector2i(7, 7),
-                    new KVector2i(7, 8),
-                    new KVector2i(5, 6),
-                    new KVector2i(7, 9),
-                    new KVector2i(3, 5),
-                    new KVector2i(5, 7),
-                    new KVector2i(5, 8),
-                    new KVector2i(3, 6),
-                    new KVector2i(5, 9),
-                    new KVector2i(3, 7),
-                    new KVector2i(5, 10),
-                    new KVector2i(3, 8),
-                    new KVector2i(3, 9)
+                    KVectors.new2i(7, 5),
+                    KVectors.new2i(7, 6),
+                    KVectors.new2i(6, 6),
+                    KVectors.new2i(4, 5),
+                    KVectors.new2i(6, 7),
+                    KVectors.new2i(6, 8),
+                    KVectors.new2i(4, 6),
+                    KVectors.new2i(6, 9),
+                    KVectors.new2i(4, 7),
+                    KVectors.new2i(6, 10),
+                    KVectors.new2i(4, 8),
+                    KVectors.new2i(2, 6),
+                    KVectors.new2i(4, 9),
+                    KVectors.new2i(2, 7),
+                    KVectors.new2i(4, 10),
+                    KVectors.new2i(8, 6),
+                    KVectors.new2i(6, 5),
+                    KVectors.new2i(8, 7),
+                    KVectors.new2i(5, 5),
+                    KVectors.new2i(7, 7),
+                    KVectors.new2i(7, 8),
+                    KVectors.new2i(5, 6),
+                    KVectors.new2i(7, 9),
+                    KVectors.new2i(3, 5),
+                    KVectors.new2i(5, 7),
+                    KVectors.new2i(5, 8),
+                    KVectors.new2i(3, 6),
+                    KVectors.new2i(5, 9),
+                    KVectors.new2i(3, 7),
+                    KVectors.new2i(5, 10),
+                    KVectors.new2i(3, 8),
+                    KVectors.new2i(3, 9)
                 )
             )
         );
@@ -301,24 +302,24 @@ public class KRaycastLevelObserverPositiveTests extends KStandardTestClass {
         Assertions.assertTrue(
             positions.containsAll(
                 List.of(
-                    new KVector2i(6, 7),
-                    new KVector2i(7, 8),
-                    new KVector2i(7, 7),
-                    new KVector2i(6, 5),
-                    new KVector2i(5, 5),
-                    new KVector2i(7, 6),
-                    new KVector2i(6, 6),
-                    new KVector2i(6, 8),
-                    new KVector2i(4, 6),
-                    new KVector2i(4, 7),
-                    new KVector2i(3, 6),
-                    new KVector2i(4, 8),
-                    new KVector2i(3, 7),
-                    new KVector2i(3, 8),
-                    new KVector2i(5, 7),
-                    new KVector2i(5, 8),
-                    new KVector2i(5, 6),
-                    new KVector2i(4, 5)
+                    KVectors.new2i(6, 7),
+                    KVectors.new2i(7, 8),
+                    KVectors.new2i(7, 7),
+                    KVectors.new2i(6, 5),
+                    KVectors.new2i(5, 5),
+                    KVectors.new2i(7, 6),
+                    KVectors.new2i(6, 6),
+                    KVectors.new2i(6, 8),
+                    KVectors.new2i(4, 6),
+                    KVectors.new2i(4, 7),
+                    KVectors.new2i(3, 6),
+                    KVectors.new2i(4, 8),
+                    KVectors.new2i(3, 7),
+                    KVectors.new2i(3, 8),
+                    KVectors.new2i(5, 7),
+                    KVectors.new2i(5, 8),
+                    KVectors.new2i(5, 6),
+                    KVectors.new2i(4, 5)
                 )
             )
         );

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderPositiveTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/KStandardLevelLoaderPositiveTests.java
@@ -31,6 +31,7 @@ import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KStandardEventSystem;
 import io.github.darthakiranihil.konna.core.struct.KPair;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.core.struct.graph.KIntWeightedGraph;
 import io.github.darthakiranihil.konna.core.util.KHashMapBasedCache;
 import io.github.darthakiranihil.konna.core.util.KReflectionUtils;
@@ -140,8 +141,8 @@ public class KStandardLevelLoaderPositiveTests extends KStandardTestClass {
 
         loaded.delete();
 
-        Assertions.assertEquals(new KPair<>(new KVector2i(0, 0), mf1), c1.get().getPosition());
-        Assertions.assertEquals(new KPair<>(new KVector2i(0, 0), mf1), s1.get().getPosition());
+        Assertions.assertEquals(new KPair<>(KVectors.new2i(0, 0), mf1), c1.get().getPosition());
+        Assertions.assertEquals(new KPair<>(KVectors.new2i(0, 0), mf1), s1.get().getPosition());
 
     }
 
@@ -195,9 +196,9 @@ public class KStandardLevelLoaderPositiveTests extends KStandardTestClass {
         TestController tc = (TestController) controller;
         Assertions.assertEquals(42069, tc.getTest());
 
-        Assertions.assertEquals(new KVector2i(1, 0), controller.getNextMoveDirection());
+        Assertions.assertEquals(KVectors.new2i(1, 0), controller.getNextMoveDirection());
         entity.move();
-        Assertions.assertEquals(new KPair<>(new KVector2i(1, 0), sector), entity.getPosition());
+        Assertions.assertEquals(new KPair<>(KVectors.new2i(1, 0), sector), entity.getPosition());
 
     }
 
@@ -223,7 +224,7 @@ public class KStandardLevelLoaderPositiveTests extends KStandardTestClass {
         Assertions.assertEquals(FalseValidatedController.class, controller.getClass());
         Assertions.assertEquals(KVector2i.ZERO, controller.getNextMoveDirection());
         entity.move();
-        Assertions.assertEquals(new KPair<>(new KVector2i(0, 0), sector), entity.getPosition());
+        Assertions.assertEquals(new KPair<>(KVectors.new2i(0, 0), sector), entity.getPosition());
 
     }
 
@@ -248,7 +249,7 @@ public class KStandardLevelLoaderPositiveTests extends KStandardTestClass {
         Assertions.assertEquals(TestControllerWithoutValidator.class, controller.getClass());
         Assertions.assertEquals(KVector2i.ZERO, controller.getNextMoveDirection());
         entity.move();
-        Assertions.assertEquals(new KPair<>(new KVector2i(0, 0), sector), entity.getPosition());
+        Assertions.assertEquals(new KPair<>(KVectors.new2i(0, 0), sector), entity.getPosition());
 
     }
 

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/KConstantNodesTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/KConstantNodesTests.java
@@ -22,6 +22,7 @@ import io.github.darthakiranihil.konna.core.io.KAssetDefinition;
 import io.github.darthakiranihil.konna.core.io.KMapAssetDefinition;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.generator.constant.*;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import org.junit.jupiter.api.Assertions;
@@ -121,7 +122,7 @@ public class KConstantNodesTests extends KStandardTestClass {
         KVector2iConstantNode node = new KVector2iConstantNode(def);
         KUniversalMap result = node.process(new KUniversalMap(), new Random());
         Assertions.assertTrue(result.containsKey("value"));
-        Assertions.assertEquals(new KVector2i(1, 1), result.get("value"));
+        Assertions.assertEquals(KVectors.new2i(1, 1), result.get("value"));
 
     }
 

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KPassabilityLayerAddNodeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KPassabilityLayerAddNodeTests.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.level.generator.maker.passability;
 import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityLayer;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityState;
 import io.github.darthakiranihil.konna.level.layer.tool.KPassabilityLayerTool;
@@ -56,7 +57,7 @@ public class KPassabilityLayerAddNodeTests extends KStandardTestClass {
         KUniversalMap params = new KUniversalMap();
         params.put("first", p1);
         params.put("second", p2);
-        params.put("offset", new KVector2i(1, 0));
+        params.put("offset", KVectors.new2i(1, 0));
         KUniversalMap nodeResult = node.process(params, new Random());
 
         Assertions.assertNotNull(nodeResult.getSafe("result", KPassabilityLayer.class));

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KPassabilityLayerSubtractNodeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KPassabilityLayerSubtractNodeTests.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.level.generator.maker.passability;
 import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityLayer;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityState;
 import io.github.darthakiranihil.konna.level.layer.tool.KPassabilityLayerTool;
@@ -57,7 +58,7 @@ public class KPassabilityLayerSubtractNodeTests extends KStandardTestClass {
         KUniversalMap params = new KUniversalMap();
         params.put("first", p1);
         params.put("second", p2);
-        params.put("offset", new KVector2i(1, 0));
+        params.put("offset", KVectors.new2i(1, 0));
         KUniversalMap nodeResult = node.process(params, new Random());
 
         Assertions.assertNotNull(nodeResult.getSafe("result", KPassabilityLayer.class));

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KRandomRectangularCenteredRoomsInPartitionNodeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KRandomRectangularCenteredRoomsInPartitionNodeTests.java
@@ -19,6 +19,7 @@ package io.github.darthakiranihil.konna.level.generator.maker.passability;
 import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityLayer;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityState;
 import io.github.darthakiranihil.konna.level.struct.KPartition;
@@ -36,16 +37,16 @@ public class KRandomRectangularCenteredRoomsInPartitionNodeTests extends KStanda
     public void testProcessSuccess() {
 
         KPartition partition = new KPartition(
-            new KVector2i(0, 0),
+            KVectors.new2i(0, 0),
             new KSize(60, 60),
             List.of(
                 new KPartition(
-                    new KVector2i(0, 0),
+                    KVectors.new2i(0, 0),
                     new KSize(30, 60),
                     List.of()
                 ),
                 new KPartition(
-                    new KVector2i(30, 0),
+                    KVectors.new2i(30, 0),
                     new KSize(30, 60),
                     List.of()
                 )
@@ -71,25 +72,25 @@ public class KRandomRectangularCenteredRoomsInPartitionNodeTests extends KStanda
     public void testProcessDepperSuccess() {
 
         KPartition partition = new KPartition(
-            new KVector2i(0, 0),
+            KVectors.new2i(0, 0),
             new KSize(120, 120),
             List.of(
                 new KPartition(
-                    new KVector2i(0, 0),
+                    KVectors.new2i(0, 0),
                     new KSize(60, 120),
                     List.of()
                 ),
                 new KPartition(
-                    new KVector2i(60, 0),
+                    KVectors.new2i(60, 0),
                     new KSize(60, 120),
                     List.of(
                         new KPartition(
-                            new KVector2i(60, 0),
+                            KVectors.new2i(60, 0),
                             new KSize(60, 60),
                             List.of()
                         ),
                         new KPartition(
-                            new KVector2i(60, 60),
+                            KVectors.new2i(60, 60),
                             new KSize(60, 60),
                             List.of()
                         )
@@ -118,7 +119,7 @@ public class KRandomRectangularCenteredRoomsInPartitionNodeTests extends KStanda
     public void testProcessOnlyOnePartitionSuccess() {
 
         KPartition partition = new KPartition(
-            new KVector2i(0, 0),
+            KVectors.new2i(0, 0),
             new KSize(120, 120),
             List.of()
         );

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KStraightPathsBetweenBinaryPartitionCentersNodeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/maker/passability/KStraightPathsBetweenBinaryPartitionCentersNodeTests.java
@@ -20,6 +20,7 @@ import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.except.KInvalidArgumentException;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityLayer;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityState;
 import io.github.darthakiranihil.konna.level.struct.KPartition;
@@ -36,25 +37,25 @@ public class KStraightPathsBetweenBinaryPartitionCentersNodeTests extends KStand
     public void testProcessSuccess() {
 
         KPartition partition = new KPartition(
-            new KVector2i(0, 0),
+            KVectors.new2i(0, 0),
             new KSize(120, 120),
             List.of(
                 new KPartition(
-                    new KVector2i(0, 0),
+                    KVectors.new2i(0, 0),
                     new KSize(60, 120),
                     List.of()
                 ),
                 new KPartition(
-                    new KVector2i(60, 0),
+                    KVectors.new2i(60, 0),
                     new KSize(60, 120),
                     List.of(
                         new KPartition(
-                            new KVector2i(60, 0),
+                            KVectors.new2i(60, 0),
                             new KSize(60, 60),
                             List.of()
                         ),
                         new KPartition(
-                            new KVector2i(60, 60),
+                            KVectors.new2i(60, 60),
                             new KSize(60, 60),
                             List.of()
                         )
@@ -85,21 +86,21 @@ public class KStraightPathsBetweenBinaryPartitionCentersNodeTests extends KStand
             KInvalidArgumentException.class,
             () -> {
                 KPartition partition = new KPartition(
-                    new KVector2i(0, 0),
+                    KVectors.new2i(0, 0),
                     new KSize(120, 120),
                     List.of(
                         new KPartition(
-                            new KVector2i(0, 0),
+                            KVectors.new2i(0, 0),
                             new KSize(60, 120),
                             List.of()
                         ),
                         new KPartition(
-                            new KVector2i(60, 0),
+                            KVectors.new2i(60, 0),
                             new KSize(60, 120),
                             List.of()
                         ),
                         new KPartition(
-                            new KVector2i(60, 0),
+                            KVectors.new2i(60, 0),
                             new KSize(60, 120),
                             List.of()
                         )
@@ -118,30 +119,30 @@ public class KStraightPathsBetweenBinaryPartitionCentersNodeTests extends KStand
             KInvalidArgumentException.class,
             () -> {
                 KPartition partition = new KPartition(
-                    new KVector2i(0, 0),
+                    KVectors.new2i(0, 0),
                     new KSize(120, 120),
                     List.of(
                         new KPartition(
-                            new KVector2i(0, 0),
+                            KVectors.new2i(0, 0),
                             new KSize(60, 120),
                             List.of()
                         ),
                         new KPartition(
-                            new KVector2i(60, 0),
+                            KVectors.new2i(60, 0),
                             new KSize(60, 120),
                             List.of(
                                 new KPartition(
-                                    new KVector2i(60, 0),
+                                    KVectors.new2i(60, 0),
                                     new KSize(60, 120),
                                     List.of()
                                 ),
                                 new KPartition(
-                                    new KVector2i(60, 0),
+                                    KVectors.new2i(60, 0),
                                     new KSize(60, 120),
                                     List.of()
                                 ),
                                 new KPartition(
-                                    new KVector2i(60, 0),
+                                    KVectors.new2i(60, 0),
                                     new KSize(60, 120),
                                     List.of()
                                 )

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/mapper/KInjectTilesNodeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/mapper/KInjectTilesNodeTests.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.generator.mapper;
 
 import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KTileInfo;
 import io.github.darthakiranihil.konna.level.layer.KTileLayer;
 import io.github.darthakiranihil.konna.level.layer.tool.KTileLayerTool;
@@ -83,7 +84,7 @@ public class KInjectTilesNodeTests extends KStandardTestClass {
         KUniversalMap params = new KUniversalMap();
         params.put("destination", l1);
         params.put("injected", l2);
-        params.put("offset", new KVector2i(1, 0));
+        params.put("offset", KVectors.new2i(1, 0));
 
         KInjectTilesNode node = new KInjectTilesNode();
         KUniversalMap nodeResult = node.process(params, new Random());

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/mapper/KMapAllLevelTransitionsToTileNodeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/mapper/KMapAllLevelTransitionsToTileNodeTests.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.generator.mapper;
 
 import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KTileInfo;
 import io.github.darthakiranihil.konna.level.layer.KLevelTransitionLayer;
 import io.github.darthakiranihil.konna.level.layer.KTileLayer;
@@ -72,11 +73,11 @@ public class KMapAllLevelTransitionsToTileNodeTests extends KStandardTestClass {
         KLevelTransitionLayer levelTransitionLayer = new KLevelTransitionLayer();
         KLevelTransitionLayerTool ltt = levelTransitionLayer.getTool();
         ltt.makeTransition(
-            new KVector2i(1, 1),
+            KVectors.new2i(1, 1),
             "left 4 ded",
             KTransitionedLevelType.GENERATED,
             "ded",
-            new KVector2i(1, 0)
+            KVectors.new2i(1, 0)
         );
 
         KUniversalMap params = new KUniversalMap();

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/math/KNegateVector2iNodeNodeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/math/KNegateVector2iNodeNodeTests.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.generator.math;
 
 import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.test.KStandardTestClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -30,11 +31,11 @@ public class KNegateVector2iNodeNodeTests extends KStandardTestClass {
     public void testProcessSuccess() {
 
         KUniversalMap params = new KUniversalMap();
-        params.put("value", new KVector2i(2, -2));
+        params.put("value", KVectors.new2i(2, -2));
         var node = new KNegateVector2iNode();
         KUniversalMap result = node.process(params, new Random(42069L));
         Assertions.assertNotNull(result.getSafe("value", KVector2i.class));
-        Assertions.assertEquals(new KVector2i(-2, 2), result.get("value", KVector2i.class));
+        Assertions.assertEquals(KVectors.new2i(-2, 2), result.get("value", KVector2i.class));
 
     }
 }

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/mutator/passability/KSimpleCellularAutomatonNodeTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/generator/mutator/passability/KSimpleCellularAutomatonNodeTests.java
@@ -20,6 +20,7 @@ import io.github.darthakiranihil.konna.core.data.KUniversalMap;
 import io.github.darthakiranihil.konna.core.except.KInvalidArgumentException;
 import io.github.darthakiranihil.konna.core.struct.KSize;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityLayer;
 import io.github.darthakiranihil.konna.level.layer.KPassabilityState;
 import io.github.darthakiranihil.konna.level.layer.tool.KPassabilityLayerTool;
@@ -57,7 +58,7 @@ public class KSimpleCellularAutomatonNodeTests extends KStandardTestClass {
         Assertions.assertEquals(KPassabilityState.IMPASSABLE, layer.getOnPosition(2, 1));
         Assertions.assertEquals(KPassabilityState.IMPASSABLE, layer.getOnPosition(1, 2));
         Assertions.assertEquals(KPassabilityState.IMPASSABLE, layer.getOnPosition(2, 2));
-        Assertions.assertEquals(KPassabilityState.IMPASSABLE, layer.getOnPosition(new KVector2i(1, 3)));
+        Assertions.assertEquals(KPassabilityState.IMPASSABLE, layer.getOnPosition(KVectors.new2i(1, 3)));
 
 
     }

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestController.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/impl/TestController.java
@@ -18,6 +18,7 @@ package io.github.darthakiranihil.konna.level.impl;
 
 import io.github.darthakiranihil.konna.core.io.KAssetDefinition;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.entity.KAutonomousEntityController;
 import io.github.darthakiranihil.konna.level.entity.KAutonomousEntityControllerParam;
 import org.jspecify.annotations.NullMarked;
@@ -39,7 +40,7 @@ public class TestController extends KAutonomousEntityController {
 
     @Override
     public KVector2i getNextMoveDirection() {
-        return new KVector2i(1, 0);
+        return KVectors.new2i(1, 0);
     }
 
     public int getTest() {

--- a/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/path/KAStarPathfinderPositiveTests.java
+++ b/implementations/implementations-std-level/src/test/java/io/github/darthakiranihil/konna/level/path/KAStarPathfinderPositiveTests.java
@@ -21,6 +21,7 @@ import io.github.darthakiranihil.konna.core.message.KEventSystem;
 import io.github.darthakiranihil.konna.core.message.KStandardEventSystem;
 import io.github.darthakiranihil.konna.core.struct.KPair;
 import io.github.darthakiranihil.konna.core.struct.KVector2i;
+import io.github.darthakiranihil.konna.core.struct.KVectors;
 import io.github.darthakiranihil.konna.level.KLevel;
 import io.github.darthakiranihil.konna.level.KLevelSector;
 import io.github.darthakiranihil.konna.level.KTileInfo;
@@ -131,8 +132,8 @@ public class KAStarPathfinderPositiveTests extends KStandardTestClass {
         KPath mn = manhattan.findPath(this.level, "s1", 1, 1, "s1", 3, 1);
 
         KVector2i[] expected = new KVector2i[] {
-            new KVector2i(1, 0),
-            new KVector2i(1, 0)
+            KVectors.new2i(1, 0),
+            KVectors.new2i(1, 0)
         };
 
         for (KVector2i el : expected) {
@@ -162,11 +163,11 @@ public class KAStarPathfinderPositiveTests extends KStandardTestClass {
         KPath mn = manhattan.findPath(this.level, "s1", 1, 1, "s2", 3, 1);
 
         KVector2i[] expected = new KVector2i[] {
-            new KVector2i(1, 0),
-            new KVector2i(1, 1),
-            new KVector2i(0, 1),
-            new KVector2i(0, 1),
-            new KVector2i(0, 1),
+            KVectors.new2i(1, 0),
+            KVectors.new2i(1, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(0, 1),
         };
 
         for (KVector2i el : expected) {
@@ -197,17 +198,17 @@ public class KAStarPathfinderPositiveTests extends KStandardTestClass {
         KPath mn = manhattan.findPath(this.level, "s1", 1, 1, "s3", 3, 3);
 
         KVector2i[] expected = new KVector2i[] {
-            new KVector2i(1, 0),
-            new KVector2i(1, 1),
-            new KVector2i(0, 1),
-            new KVector2i(0, 1),
-            new KVector2i(0, 1),
-            new KVector2i(0, 1),
-            new KVector2i(-1, 1),
-            new KVector2i(-1, 0),
-            new KVector2i(-1, 0),
-            new KVector2i(-1, 0),
-            // new KVector2i(-1, 0),
+            KVectors.new2i(1, 0),
+            KVectors.new2i(1, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(-1, 1),
+            KVectors.new2i(-1, 0),
+            KVectors.new2i(-1, 0),
+            KVectors.new2i(-1, 0),
+            // KVectors.new2i(-1, 0),
         };
 
         for (KVector2i el : expected) {
@@ -238,21 +239,21 @@ public class KAStarPathfinderPositiveTests extends KStandardTestClass {
         KPath mn = manhattan.findPath(this.level, "s1", 1, 1, "s4", 1, 3);
 
         KVector2i[] expected = new KVector2i[] {
-            new KVector2i(1, 0),
-            new KVector2i(1, 1),
-            new KVector2i(0, 1),
-            new KVector2i(0, 1),
-            new KVector2i(0, 1),
-            new KVector2i(0, 1),
-            new KVector2i(-1, 1),
-            new KVector2i(-1, 0),
-            new KVector2i(-1, 0),
-            new KVector2i(-1, 0),
-            new KVector2i(-1, 0),
-            new KVector2i(-1, -1),
-            new KVector2i(0, -1),
-            new KVector2i(0, -1),
-            new KVector2i(0, -1),
+            KVectors.new2i(1, 0),
+            KVectors.new2i(1, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(0, 1),
+            KVectors.new2i(-1, 1),
+            KVectors.new2i(-1, 0),
+            KVectors.new2i(-1, 0),
+            KVectors.new2i(-1, 0),
+            KVectors.new2i(-1, 0),
+            KVectors.new2i(-1, -1),
+            KVectors.new2i(0, -1),
+            KVectors.new2i(0, -1),
+            KVectors.new2i(0, -1),
         };
 
         for (KVector2i el : expected) {
@@ -412,12 +413,12 @@ public class KAStarPathfinderPositiveTests extends KStandardTestClass {
         KPath mn = manhattan.findPath(loc2, "s1", 3, 1, "s1", 1, 1);
 
         KVector2i[] expected = new KVector2i[] {
-            new KVector2i(1, 0),
-            new KVector2i(1, 0),
-            new KVector2i(1, 0),
-            new KVector2i(1, 0),
-            new KVector2i(1, 0),
-            new KVector2i(1, 0),
+            KVectors.new2i(1, 0),
+            KVectors.new2i(1, 0),
+            KVectors.new2i(1, 0),
+            KVectors.new2i(1, 0),
+            KVectors.new2i(1, 0),
+            KVectors.new2i(1, 0),
         };
 
         for (KVector2i el : expected) {
@@ -677,7 +678,7 @@ public class KAStarPathfinderPositiveTests extends KStandardTestClass {
         KPathfinder naturalizedChebyshev = new KAStarPathfinder();
         KPathfinder manhattan = new KAStarPathfinder(KAStarPathfinder.Heuristic.MANHATTAN);
 
-        KPath ep = euclidean.findPath(loc2, new KPair<>("s1", new KVector2i(3, 1)), new KPair<>("s4", new KVector2i(3, 4)));
+        KPath ep = euclidean.findPath(loc2, new KPair<>("s1", KVectors.new2i(3, 1)), new KPair<>("s4", KVectors.new2i(3, 4)));
         KPath ch = chebyshev.findPath(loc2, "s1", 3, 1, "s4", 3, 4);
         KPath nch = naturalizedChebyshev.findPath(loc2, "s1", 3, 1, "s4", 3, 4);
         KPath mn = manhattan.findPath(loc2, "s1", 3, 1, "s4", 3, 4);


### PR DESCRIPTION
1. ref: make vectors classes instead of records and make their constructors private
2. feat: add KVectors - factory class for vectors
3. feat: add saving allocated vectors in order to reuse them